### PR TITLE
bazel_drake_external: Add LOCAL_DRAKE_PATH env var

### DIFF
--- a/drake_bazel_external/BUILD.bazel
+++ b/drake_bazel_external/BUILD.bazel
@@ -1,0 +1,34 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# Copyright (c) 2019, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# This is an empty BUILD file, to ensure that this project's root directory is
+# a Bazel package.

--- a/drake_bazel_external/WORKSPACE
+++ b/drake_bazel_external/WORKSPACE
@@ -30,6 +30,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+workspace(name = "drake_external_examples")
+
 DRAKE_COMMIT = "master"
 DRAKE_CHECKSUM = ""
 
@@ -40,10 +42,21 @@ DRAKE_CHECKSUM = ""
 # displays the suggested new value for the CHECKSUM.
 # DRAKE_CHECKSUM = "0" * 64
 
-# Download Drake.
+# Or to temporarily build against a local checkout of Drake, at the bash prompt
+# set an environment variable before building:
+#  export EXAMPLES_LOCAL_DRAKE_PATH=/home/user/stuff/drake
+
+# Load an environment variable.
+load("//:environ.bzl", "environ_repository")
+environ_repository(name = "environ", vars = ["EXAMPLES_LOCAL_DRAKE_PATH"])
+load("@environ//:environ.bzl", EXAMPLES_LOCAL_DRAKE_PATH = "EXAMPLES_LOCAL_DRAKE_PATH")
+
+# This declares the `@drake` repository as an http_archive from github,
+# iff EXAMPLES_LOCAL_DRAKE_PATH is unset.  When it is set, this declares a
+# `@drake_ignored` package which is never referenced, and thus is ignored.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
-    name = "drake",
+    name = "drake" if not EXAMPLES_LOCAL_DRAKE_PATH else "drake_ignored",
     urls = [x.format(DRAKE_COMMIT) for x in [
         "https://github.com/RobotLocomotion/drake/archive/{}.tar.gz",
     ]],
@@ -51,12 +64,14 @@ http_archive(
     strip_prefix = "drake-{}".format(DRAKE_COMMIT),
 )
 
-# To use a local checkout of Drake instead of the github.com download described
-# above, replace the http_archive stanza with something like the following:
-#   local_repository(
-#       name = "drake",
-#       path = "/path/to/git/drake",
-#   )
+# This declares the `@drake` repository as a local directory,
+# iff EXAMPLES_LOCAL_DRAKE_PATH is set.  When it is unset, this declares a
+# `@drake_ignored` package which is never referenced, and thus is ignored.
+local_repository(
+    name = "drake" if EXAMPLES_LOCAL_DRAKE_PATH else "drake_ignored",
+    path = EXAMPLES_LOCAL_DRAKE_PATH,
+)
+print("Using EXAMPLES_LOCAL_DRAKE_PATH={}".format(EXAMPLES_LOCAL_DRAKE_PATH)) if EXAMPLES_LOCAL_DRAKE_PATH else None  # noqa
 
 # Reference external software libraries and tools per Drake's defaults.  Some
 # software will come from the host system (Ubuntu or macOS); other software

--- a/drake_bazel_external/environ.bzl
+++ b/drake_bazel_external/environ.bzl
@@ -1,0 +1,70 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# Copyright (c) 2018, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Write out a repository that contains:
+# - An empty BUILD file, to define a package.
+# - An environ.bzl file with variable assignments for each ENV_NAMES item.
+def _impl(repository_ctx):
+    vars = repository_ctx.attr._vars
+    bzl_content = []
+    for key in vars:
+        value = repository_ctx.os.environ.get(key, "")
+        bzl_content.append("{}='{}'\n".format(key, value))
+    repository_ctx.file(
+        "BUILD.bazel",
+        content = "\n",
+        executable = False,
+    )
+    repository_ctx.file(
+        "environ.bzl",
+        content = "".join(bzl_content),
+        executable = False,
+    )
+
+def environ_repository(name = None, vars = []):
+    """Provide specific environment variables for use in a WORKSPACE file.
+    The `vars` are the environment variables to provide.
+
+    Example:
+        environ_repository(name = "foo", vars = ["BAR", "BAZ"])
+        load("@foo//:environ.bzl", "BAR", "BAZ")
+        print(BAR)
+    """
+    rule = repository_rule(
+        implementation = _impl,
+        attrs = {
+            "_vars": attr.string_list(default = vars),
+        },
+        local = True,
+        environ = vars,
+    )
+    rule(name = name)


### PR DESCRIPTION
This shows the workflow that TRI's Drake team uses to consume Drake as an external.  It came up on slack that others non-TRI users might be interested in doing the same.

This change complicates the sample WORKSPACE -- it's no longer the simplest thing possible.  It's possible that we should offer both skeletons to users.  (We could also then enhance the more complicated skeleton to show even more affordances, such as linter integration.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/137)
<!-- Reviewable:end -->
