### PR TITLE
Use AdvanceTo() rather than deprecated StepTo() name

### DIFF
--- a/drake_bazel_external/apps/simple_adder_py_test.py
+++ b/drake_bazel_external/apps/simple_adder_py_test.py
@@ -61,7 +61,7 @@ def main():
     diagram = builder.Build()
 
     simulator = Simulator(diagram)
-    simulator.StepTo(1)
+    simulator.AdvanceTo(1)
 
     x = logger.data()
     print("Output values: {}".format(x))

--- a/drake_bazel_external/apps/simple_adder_test.cc
+++ b/drake_bazel_external/apps/simple_adder_test.cc
@@ -64,7 +64,7 @@ int DoMain() {
   auto diagram = builder.Build();
 
   Simulator<double> simulator(*diagram);
-  simulator.StepTo(1);
+  simulator.AdvanceTo(1);
 
   auto x = logger->data();
   Eigen::VectorXd x_expected = Eigen::Vector2d(110., 110.);

--- a/drake_bazel_external/apps/simple_continuous_time_system.cc
+++ b/drake_bazel_external/apps/simple_continuous_time_system.cc
@@ -106,7 +106,7 @@ int main() {
   state[0] = 0.9;
 
   // Simulate for 10 seconds.
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
   DRAKE_DEMAND(state[0] < 1.0e-4);

--- a/drake_bazel_external/apps/simple_logging_example.py
+++ b/drake_bazel_external/apps/simple_logging_example.py
@@ -53,7 +53,7 @@ def main():
     diagram = builder.Build()
 
     simulator = Simulator(diagram)
-    simulator.StepTo(1)
+    simulator.AdvanceTo(1)
 
     x = logger.data()
     print("Output values: {}".format(x))

--- a/drake_cmake_external/drake_external_examples/apps/simple_continuous_time_system.cc
+++ b/drake_cmake_external/drake_external_examples/apps/simple_continuous_time_system.cc
@@ -106,7 +106,7 @@ int main() {
   state[0] = 0.9;
 
   // Simulate for 10 seconds.
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
   DRAKE_DEMAND(state[0] < 1.0e-4);

--- a/drake_cmake_installed/src/pcl/drake_camera_example.cc
+++ b/drake_cmake_installed/src/pcl/drake_camera_example.cc
@@ -88,7 +88,7 @@ int main() {
   auto diagram = builder.Build();
   auto simulator =
       std::make_unique<drake::systems::Simulator<double>>(*diagram);
-  simulator->StepTo(0.1);
+  simulator->AdvanceTo(0.1);
 
   // TODO(eric.cousineau): Add in example of converting depth image to PCL
   // point cloud.

--- a/drake_cmake_installed/src/simple_bindings/simple_bindings_test.py
+++ b/drake_cmake_installed/src/simple_bindings/simple_bindings_test.py
@@ -57,7 +57,7 @@ def main():
     diagram = builder.Build()
 
     simulator = Simulator(diagram)
-    simulator.StepTo(1)
+    simulator.AdvanceTo(1)
 
     x = logger.data()
     print("Output values: {}".format(x))

--- a/drake_cmake_installed/src/simple_continuous_time_system/simple_continuous_time_system.cc
+++ b/drake_cmake_installed/src/simple_continuous_time_system/simple_continuous_time_system.cc
@@ -106,7 +106,7 @@ int main() {
   state[0] = 0.9;
 
   // Simulate for 10 seconds.
-  simulator.StepTo(10);
+  simulator.AdvanceTo(10);
 
   // Make sure the simulation converges to the stable fixed point at x=0.
   DRAKE_DEMAND(state[0] < 1.0e-4);


### PR DESCRIPTION
Simulator::StepTo() is now deprecated in favor of Simulator::AdvanceTo(). This PR makes that change in all the drake-external-examples code.

Fixes RobotLocomotion/drake#12025

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/141)
<!-- Reviewable:end -->
