### PR TITLE
Add --incompatible_remove_legacy_whole_archive=no to bazelrc

### DIFF
--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -34,6 +34,10 @@ build --incompatible_py3_is_default=no
 # than a toolchain in Bazel 0.27 and above.
 build --incompatible_use_python_toolchains=no
 
+# Continue to use --whole-archive for cc_binary rules that have linkshared = 1
+# and either linkstatic = 1 or -static in linkopts in Bazel 1.0 and above.
+build --incompatible_remove_legacy_whole_archive=no
+
 # Default to an optimized build.
 build --compilation_mode=opt
 


### PR DESCRIPTION
Flag was switched from no to yes in Bazel 1.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/143)
<!-- Reviewable:end -->
