### PR TITLE
Fix gflags imported target for Ubuntu

### DIFF
--- a/drake_cmake_installed/src/particles/CMakeLists.txt
+++ b/drake_cmake_installed/src/particles/CMakeLists.txt
@@ -36,11 +36,12 @@ configure_file(models/particle.sdf "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
 add_library(particles particle.cc particle.h utilities.cc utilities.h)
 target_link_libraries(particles drake::drake)
 
-find_package(gflags CONFIG REQUIRED COMPONENTS shared)
+set(GFLAGS_USE_TARGET_NAMESPACE OFF)
+find_package(gflags CONFIG REQUIRED)
 
 add_executable(uniformly_accelerated_particle uniformly_accelerated_particle.cc)
 target_link_libraries(uniformly_accelerated_particle particles
-  drake::drake drake::drake-common-text-logging-gflags gflags::gflags_shared
+  drake::drake drake::drake-common-text-logging-gflags gflags
 )
 
 add_executable(particle_test particle_test.cc)


### PR DESCRIPTION
Most likely requires RobotLocomotion/drake#12250.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/146)
<!-- Reviewable:end -->
