### PR TITLE
Add drake_bazel_installed example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Examples of how to use [Drake](https://github.com/RobotLocomotion/drake) in your
 own project:
 
 * [`drake_bazel_external`](./drake_bazel_external)
+* [`drake_bazel_installed`](./drake_bazel_installed)
 * [`drake_cmake_external`](./drake_cmake_external)
 * [`drake_cmake_installed`](./drake_cmake_installed)
 
@@ -18,10 +19,12 @@ Scripts are provided for various CI instances in `scripts/continuous_integration
 | **Subproject** | **Circle CI** | **Jenkins** | **Travis CI** |
 |:---:|:---:|:---:|:---:|
 | `drake_bazel_external` | - | o | - |
+| `drake_bazel_installed` | o | o | - |
 | `drake_cmake_external` | - | o | - |
 | `drake_cmake_installed` | o | o | o |
 ||[![CircleCI](https://img.shields.io/circleci/project/github/RobotLocomotion/drake-external-examples/master.svg)](https://circleci.com/gh/RobotLocomotion/drake-external-examples)|[![Jenkins](https://img.shields.io/jenkins/s/https/drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/job/master.svg)](https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/)|[![Travis CI](https://img.shields.io/travis/com/RobotLocomotion/drake-external-examples/master.svg)](https://travis-ci.com/RobotLocomotion/drake-external-examples)
 
-Note, the Circle CI and Travis CI jobs only build and test `drake_cmake_installed`
-since it is the exemplary case for a lightweight, open-source build on a public
-CI server.
+Note, the Circle CI jobs only build and test `drake_bazel_installed` and
+`drake_cmake_installed` and the Travis CI jobs only build and test
+`drake_cmake_installed` since these are the exemplary cases for a lightweight,
+open-source build on a public CI server.

--- a/drake_bazel_installed/.bazelrc
+++ b/drake_bazel_installed/.bazelrc
@@ -1,0 +1,56 @@
+# Copyright (c) 2018, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Continue to obtain the python runtime from the --python_version flag rather
+# than a toolchain in Bazel 0.27 and above.
+build --incompatible_use_python_toolchains=no
+
+# Default to an optimized build.
+build --compilation_mode=opt
+
+# Default build options.
+build --force_pic=yes
+build --strip=never
+
+# Default test options.
+build --test_output=errors
+build --test_summary=terse
+
+# Use C++17.
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
+
+# https://github.com/bazelbuild/bazel/issues/1164
+build --action_env=CCACHE_DISABLE=1
+
+# TODO(jwnimmer-tri) We should see if we can reuse more of Drake's
+# customizations somehow.
+
+# Try to import user-specific configuration local to workspace.
+try-import %workspace%/user.bazelrc

--- a/drake_bazel_installed/.bazelrc
+++ b/drake_bazel_installed/.bazelrc
@@ -27,10 +27,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Continue to obtain the python runtime from the --python_version flag rather
-# than a toolchain in Bazel 0.27 and above.
-build --incompatible_use_python_toolchains=no
-
 # Default to an optimized build.
 build --compilation_mode=opt
 

--- a/drake_bazel_installed/.gitignore
+++ b/drake_bazel_installed/.gitignore
@@ -1,0 +1,31 @@
+# Copyright (c) 2017, Massachusetts Institute of Technology.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+/bazel-*
+/user.bazelrc

--- a/drake_bazel_installed/BUILD.bazel
+++ b/drake_bazel_installed/BUILD.bazel
@@ -1,0 +1,34 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# Copyright (c) 2019, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# This is an empty BUILD file, to ensure that this project's root directory is
+# a Bazel package.

--- a/drake_bazel_installed/README.md
+++ b/drake_bazel_installed/README.md
@@ -1,0 +1,36 @@
+# Bazel Project with Drake as an External
+
+This pulls in Drake via the Bazel workspace mechanism.
+
+For an introduction to Bazel, refer to
+[Getting Started with Bazel](https://docs.bazel.build/versions/master/getting-started.html).
+
+## Instructions
+
+First, install the required Ubuntu packages:
+
+```
+sudo ../scripts/setup/linux/ubuntu/bionic/install_prereqs
+```
+
+Then, to build and test all apps:
+```
+bazel test //...
+```
+
+As an example to run a binary directly:
+```
+bazel run //apps:simple_logging_example
+```
+
+You may also run the binary directly per the `bazel-bin/...` path that the
+above command prints out; however, be aware that your working directories may
+cause differences.  This is important when using tools like
+`drake::FindResource` / `pydrake.common.FindResource`.
+You may generally want to stick to using `bazel run` when able.
+
+## Python Versions
+
+By default, Python 3 is the Python interpreter that Drake will use when built
+with Bazel. To see which Python versions are supported, see the
+[supported configurations](https://drake.mit.edu/developers.html#supported-configurations).

--- a/drake_bazel_installed/README.md
+++ b/drake_bazel_installed/README.md
@@ -1,6 +1,7 @@
-# Bazel Project with Drake as an External
+# Bazel Project with Drake as a Precompiled External
 
-This pulls in Drake via the Bazel workspace mechanism.
+This pulls in a downloaded or installed binary build of Drake via the Bazel
+workspace mechanism.
 
 For an introduction to Bazel, refer to
 [Getting Started with Bazel](https://docs.bazel.build/versions/master/getting-started.html).
@@ -28,9 +29,3 @@ above command prints out; however, be aware that your working directories may
 cause differences.  This is important when using tools like
 `drake::FindResource` / `pydrake.common.FindResource`.
 You may generally want to stick to using `bazel run` when able.
-
-## Python Versions
-
-By default, Python 3 is the Python interpreter that Drake will use when built
-with Bazel. To see which Python versions are supported, see the
-[supported configurations](https://drake.mit.edu/developers.html#supported-configurations).

--- a/drake_bazel_installed/WORKSPACE
+++ b/drake_bazel_installed/WORKSPACE
@@ -1,7 +1,7 @@
 # -*- mode: python -*-
 # vi: set ft=python :
 
-# Copyright (c) 2018-2019, Toyota Research Institute.
+# Copyright (c) 2019, Toyota Research Institute.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,29 +30,35 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Make a simple Python application.
-py_binary(
-    name = "simple_logging_example",
-    srcs = ["simple_logging_example.py"],
-    deps = [
-        "@drake//bindings/pydrake",
-    ],
-)
+workspace(name = "drake_external_examples")
 
-# This ensures that downstream Bazel projects can use Drake's `find_resource`
-# functionality without needing to resort to environment variables.
-py_test(
-    name = "find_resource_test",
-    srcs = ["find_resource_test.py"],
-    deps = [
-        "@drake//bindings/pydrake",
-    ],
-)
+# Choose which nightly build of Drake to use.
+DRAKE_RELEASE = "latest"  # Can also use YYYYMMDD here, e.g., "20191026".
+DRAKE_CHECKSUM = ""       # When using YYYYMMDD, best to add a checksum here.
 
-sh_test(
-    name = "simple_logging_example_test",
-    size = "small",
-    srcs = ["exec.sh"],
-    args = ["$(location :simple_logging_example)"],
-    data = [":simple_logging_example"],
-)
+# To use a local unpacked Drake binary release instead of an http download, set
+# this variable to the correct path, e.g., "/opt/drake".
+INSTALLED_DRAKE_DIR = None
+
+# This is only relevant when INSTALLED_DRAKE_DIR is set.
+new_local_repository(
+    name = "drake_artifacts",
+    path = INSTALLED_DRAKE_DIR,
+    build_file_content = "#",
+) if INSTALLED_DRAKE_DIR else None
+
+# This is only relevant when INSTALLED_DRAKE_DIR is unset.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "drake_artifacts",
+    url = "https://drake-packages.csail.mit.edu/drake/nightly/drake-{}-bionic.tar.gz".format(DRAKE_RELEASE),
+    sha256 = DRAKE_CHECKSUM,
+    strip_prefix = "drake/",
+    build_file_content = "#",
+) if not INSTALLED_DRAKE_DIR else None
+
+# Load and run the repository rule that knows how to provide the @drake
+# repository based on a Drake binary release.
+load("@drake_artifacts//:share/drake/repo.bzl", "drake_repository")
+
+drake_repository(name = "drake")

--- a/drake_bazel_installed/apps/BUILD.bazel
+++ b/drake_bazel_installed/apps/BUILD.bazel
@@ -1,0 +1,130 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# Copyright (c) 2018, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+load(
+    "@drake//tools/skylark:pybind.bzl",
+    "pybind_py_library",
+)
+
+# Compile a sample application.
+cc_binary(
+    name = "simple_continuous_time_system",
+    srcs = ["simple_continuous_time_system.cc"],
+    deps = [
+        "@drake//systems/analysis",
+        "@drake//systems/framework",
+    ],
+)
+
+# Make a simple Python application.
+py_binary(
+    name = "simple_logging_example",
+    srcs = ["simple_logging_example.py"],
+    deps = [
+        "@drake//bindings/pydrake",
+    ],
+)
+
+# This ensures that downstream Bazel projects can use Drake's `find_resource`
+# functionality without needing to resort to environment variables.
+py_test(
+    name = "find_resource_test",
+    srcs = ["find_resource_test.py"],
+    deps = [
+        "@drake//bindings/pydrake",
+    ],
+)
+
+# Run the applications to make sure they complete successfully.
+# N.B. For actual development, you should prefer language-specific test rules,
+# such as `cc_test` and `py_test`.
+sh_test(
+    name = "simple_continuous_time_system_test",
+    size = "small",
+    srcs = [":simple_continuous_time_system"],
+)
+
+sh_test(
+    name = "simple_logging_example_test",
+    size = "small",
+    srcs = ["exec.sh"],
+    args = ["$(location :simple_logging_example)"],
+    data = [":simple_logging_example"],
+)
+
+# For custom bindings, you *must* link against `drake_shared_library` for *all*
+# C++ libraries; not doing so will lead to ODR (One Definition Rule) linking
+# issues.
+cc_library(
+    name = "simple_adder",
+    srcs = [
+        # While the `*-inl.h` pattern is not required, this does ensure that we
+        # test separate compilation and linking.
+        "simple_adder.cc",
+        "simple_adder-inl.h",
+    ],
+    hdrs = [
+        "simple_adder.h",
+    ],
+    deps = [
+        # N.B. Per the above comment, this does NOT link to static libraries
+        # (e.g. "@drake//systems/analysis").
+        "@drake//:drake_shared_library",
+    ],
+)
+
+# Show that the C++ functionality works as-is.
+cc_test(
+    name = "simple_adder_test",
+    srcs = ["simple_adder_test.cc"],
+    deps = [":simple_adder"],
+)
+
+pybind_py_library(
+    name = "simple_adder_py",
+    cc_so_name = "simple_adder",
+    cc_srcs = ["simple_adder_py.cc"],
+    cc_deps = [
+        ":simple_adder",
+        "@drake//bindings/pydrake/common:cpp_template_pybind",
+        "@drake//bindings/pydrake/common:default_scalars_pybind",
+    ],
+    py_deps = ["@drake//bindings/pydrake"],
+    py_imports = ["."],
+)
+
+# Mimic the C++ test in Python to show the bindings.
+py_test(
+    name = "simple_adder_py_test",
+    srcs = ["simple_adder_py_test.py"],
+    deps = [":simple_adder_py"],
+)

--- a/drake_bazel_installed/apps/exec.sh
+++ b/drake_bazel_installed/apps/exec.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) 2018, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Proxy script for things such as passing a `py_binary` to a `sh_test`, since
+# we cannot list the Python binary in `srcs` for the test.
+exec "$@"

--- a/drake_bazel_installed/apps/find_resource_test.py
+++ b/drake_bazel_installed/apps/find_resource_test.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2019, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Provides an example (and test) of finding resources with Python from a Bazel
+project.
+"""
+
+from pydrake.common import FindResourceOrThrow, set_log_level
+
+# If you have trouble finding resources, you can enable trace logging to see
+# how `FindResource*` is searching.
+set_log_level("trace")
+
+FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf")

--- a/drake_bazel_installed/apps/simple_logging_example.py
+++ b/drake_bazel_installed/apps/simple_logging_example.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2018, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Provides an example of using pydrake from a Bazel external.
+"""
+
+from __future__ import print_function
+
+import numpy as np
+
+from pydrake.systems.analysis import Simulator
+from pydrake.systems.framework import (
+    DiagramBuilder,
+)
+from pydrake.systems.primitives import (
+    ConstantVectorSource,
+    SignalLogger,
+)
+
+
+def main():
+    builder = DiagramBuilder()
+    source = builder.AddSystem(ConstantVectorSource([10.]))
+    logger = builder.AddSystem(SignalLogger(1))
+    builder.Connect(source.get_output_port(0), logger.get_input_port(0))
+    diagram = builder.Build()
+
+    simulator = Simulator(diagram)
+    simulator.AdvanceTo(1)
+
+    x = logger.data()
+    print("Output values: {}".format(x))
+    assert np.allclose(x, 10.)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/continuous_integration/circle_ci/build_test
+++ b/scripts/continuous_integration/circle_ci/build_test
@@ -32,3 +32,4 @@
 set -eux
 
 ./scripts/continuous_integration/common/drake_cmake_installed
+./scripts/continuous_integration/common/drake_bazel_installed

--- a/scripts/continuous_integration/common/drake_bazel_installed
+++ b/scripts/continuous_integration/common/drake_bazel_installed
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2017, Massachusetts Institute of Technology.
+# Copyright (c) 2020, Massachusetts Institute of Technology.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,10 @@
 
 set -eux
 
-./scripts/continuous_integration/common/drake_bazel_external
-./scripts/continuous_integration/common/drake_cmake_external
-./scripts/continuous_integration/common/drake_bazel_installed
-./scripts/continuous_integration/common/drake_cmake_installed
+bazel version
+
+pushd drake_bazel_installed
+
+bazel test ...
+
+popd

--- a/scripts/continuous_integration/common/linux_ubuntu_bionic
+++ b/scripts/continuous_integration/common/linux_ubuntu_bionic
@@ -34,3 +34,12 @@ set -eux
 export DEBIAN_FRONTEND='noninteractive'
 
 yes | ./scripts/setup/linux/ubuntu/bionic/install_prereqs
+
+# TODO(jamiesnape): Some variation of this should probably be in the Drake
+# install tree rather than here.
+apt-get update
+apt-get install --no-install-recommends --yes apt-transport-https gnupg
+wget -O - https://bazel.build/bazel-release.pub.gpg | apt-key add
+echo 'deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8' > /etc/apt/sources.list.d/bazel.list
+apt-get update
+apt-get install --no-install-recommends --yes bazel


### PR DESCRIPTION
As requested by https://github.com/RussTedrake/manipulation/pull/4, for discussion.  (Not intended to be merged promptly.)

Only supports `pydrake` for now (no C++, no examples binaries, no lcm-spy, etc.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/152)
<!-- Reviewable:end -->
