### PR TITLE
Add libgflags-dev explicitly

### DIFF
--- a/drake_cmake_installed/src/particles/CMakeLists.txt
+++ b/drake_cmake_installed/src/particles/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(gflags CONFIG REQUIRED)
 
 add_executable(uniformly_accelerated_particle uniformly_accelerated_particle.cc)
 target_link_libraries(uniformly_accelerated_particle particles
-  drake::drake drake::drake-common-text-logging-gflags gflags
+  drake::drake gflags
 )
 
 add_executable(particle_test particle_test.cc)

--- a/drake_cmake_installed/src/particles/uniformly_accelerated_particle.cc
+++ b/drake_cmake_installed/src/particles/uniformly_accelerated_particle.cc
@@ -44,7 +44,6 @@
 
 #include <drake/common/drake_copyable.h>
 #include <drake/common/eigen_types.h>
-#include <drake/common/text_logging_gflags.h>
 #include <drake/multibody/joints/floating_base_types.h>
 #include <drake/multibody/parsers/sdf_parser.h>
 #include <drake/multibody/rigid_body_plant/drake_visualizer.h>
@@ -170,7 +169,6 @@ int main(int argc, char* argv[]) {
       "A very simple demonstration, "
       "make sure drake-visualizer is running!");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
-  drake::logging::HandleSpdlogGflags();
   // Instantiate example system.
   auto system = std::make_unique<UniformlyAcceleratedParticle>(
       FLAGS_acceleration);

--- a/scripts/setup/linux/ubuntu/bionic/install_prereqs
+++ b/scripts/setup/linux/ubuntu/bionic/install_prereqs
@@ -84,6 +84,7 @@ libbz2-dev
 libclang-dev
 libexpat1-dev
 libfreetype6-dev
+libgflags-dev
 libglib2.0-dev
 libglu1-mesa-dev
 libhdf5-dev


### PR DESCRIPTION
Previously we inherited this from `drake/setup/install_prereqs`, but as of recently Drake only adds the shared library, not the headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/160)
<!-- Reviewable:end -->
