### PR TITLE
drake_cmake_installed: Address upstream's -fvisibility settings

### DIFF
--- a/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
@@ -34,6 +34,15 @@ find_package(pybind11 CONFIG REQUIRED)
 
 pybind11_add_module(simple_bindings MODULE simple_bindings.cc)
 target_link_libraries(simple_bindings PUBLIC drake::drake)
+# N.B. `pybind11_add_module` normally sets the default visibility to "hidden"
+# to avoid warnings. However, we need the default visibility to be public so
+# template instantions that are bound in Python (e.g. `drake::Value<>`)
+# maintain the same RTTI across translation units.
+# Additionally, in Drake we avoid mixing hidden and public symbols, so we
+# can confidently re-enable this setting for Drake's symbols.
+# For more information, see:
+# https://github.com/pybind/pybind11/issues/2479
+set_target_properties(simple_bindings PROPERTIES CXX_VISIBILITY_PRESET default)
 
 add_test(NAME simple_bindings_test COMMAND
     "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/simple_bindings_test.py")

--- a/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
@@ -33,7 +33,7 @@
 find_package(pybind11 CONFIG REQUIRED)
 
 pybind11_add_module(simple_bindings MODULE simple_bindings.cc)
-target_link_libraries(simple_bindings PUBLIC drake::drake pybind11::module)
+target_link_libraries(simple_bindings PUBLIC drake::drake)
 
 add_test(NAME simple_bindings_test COMMAND
     "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/simple_bindings_test.py")


### PR DESCRIPTION
Towards RobotLocomotion/drake#14047

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/187)
<!-- Reviewable:end -->
