### PR TITLE
Change default branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 12 * * *'
 jobs:
   macos_catalina:
     name: macos catalina 10.15

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node('drake-external-examples-linux-bionic-unprovisioned') {
   timeout(600) {
     ansiColor('xterm') {
       def triggers = []
-      if (env.BRANCH_NAME == 'master') {
+      if (env.BRANCH_NAME == 'main') {
         triggers << cron('H H(7-8) * * *')
       }
       properties ([
@@ -54,7 +54,7 @@ node('drake-external-examples-linux-bionic-unprovisioned') {
           }
         }
       } catch (e) {
-        if (env.BRANCH_NAME == 'master') {
+        if (env.BRANCH_NAME == 'main') {
           emailext (
             subject: "Build failed in Jenkins: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
             body: "See <${env.BUILD_URL}display/redirect?page=changes>",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Scripts are provided for various CI instances in `scripts/continuous_integration
 | `drake_catkin_installed` | o | o | 
 | `drake_cmake_external` | - | o |
 | `drake_cmake_installed` | o | o | 
-|| ![GitHub Actions](https://img.shields.io/github/workflow/status/RobotLocomotion/drake-external-examples/ci/master) | [![Jenkins](https://img.shields.io/jenkins/build.svg?jobUrl=https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/job/master)](https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/) |
+|| ![GitHub Actions](https://img.shields.io/github/workflow/status/RobotLocomotion/drake-external-examples/ci/main) | [![Jenkins](https://img.shields.io/jenkins/build.svg?jobUrl=https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/job/main)](https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/) |
 
 Note, the GitHub Actions jobs only build and test `drake_ament_cmake_installed`,
 `drake_bazel_installed`, `drake_catkin_installed`, and `drake_cmake_installed`


### PR DESCRIPTION
Needs GitHub configuration change. Jenkins will re-index the default branch automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/202)
<!-- Reviewable:end -->
