### PR TITLE
Remove uses of implicitly-defaulted port names

### DIFF
--- a/drake_ament_cmake_installed/src/drake_ament_cmake_installed/src/particle.cc
+++ b/drake_ament_cmake_installed/src/drake_ament_cmake_installed/src/particle.cc
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2017-2020, Massachusetts Institute of Technology.
+ * Copyright (c) 2017-2021, Massachusetts Institute of Technology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,13 @@ namespace particles {
 template <typename T>
 Particle<T>::Particle() {
   // A 1D input vector for acceleration.
-  this->DeclareInputPort(drake::systems::kVectorValued, 1);
+  this->DeclareInputPort(drake::systems::kUseDefaultName,
+                         drake::systems::kVectorValued, 1);
   // Adding one generalized position and one generalized velocity.
   this->DeclareContinuousState(1, 1, 0);
   // A 2D output vector for position and velocity.
-  this->DeclareVectorOutputPort(drake::systems::BasicVector<T>(2),
+  this->DeclareVectorOutputPort(drake::systems::kUseDefaultName,
+                                drake::systems::BasicVector<T>(2),
                                 &Particle::CopyStateOut);
 }
 

--- a/drake_bazel_external/apps/simple_adder-inl.h
+++ b/drake_bazel_external/apps/simple_adder-inl.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2018, Toyota Research Institute
+ * Copyright (c) 2018-2021, Toyota Research Institute
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,9 +50,9 @@ using drake::systems::kVectorValued;
 template <typename T>
 SimpleAdder<T>::SimpleAdder(T add)
       : add_(add) {
-  this->DeclareInputPort(kVectorValued, 1);
+  this->DeclareInputPort("in", kVectorValued, 1);
   this->DeclareVectorOutputPort(
-      BasicVector<T>(1), &SimpleAdder::CalcOutput);
+      "out", BasicVector<T>(1), &SimpleAdder::CalcOutput);
 }
 
 template <typename T>

--- a/drake_catkin_installed/src/drake_catkin_installed/src/drake_catkin_installed/particle.cc
+++ b/drake_catkin_installed/src/drake_catkin_installed/src/drake_catkin_installed/particle.cc
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2017-2020, Massachusetts Institute of Technology.
+ * Copyright (c) 2017-2021, Massachusetts Institute of Technology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,13 @@ namespace particles {
 template <typename T>
 Particle<T>::Particle() {
   // A 1D input vector for acceleration.
-  this->DeclareInputPort(drake::systems::kVectorValued, 1);
+  this->DeclareInputPort(drake::systems::kUseDefaultName,
+                         drake::systems::kVectorValued, 1);
   // Adding one generalized position and one generalized velocity.
   this->DeclareContinuousState(1, 1, 0);
   // A 2D output vector for position and velocity.
-  this->DeclareVectorOutputPort(drake::systems::BasicVector<T>(2),
+  this->DeclareVectorOutputPort(drake::systems::kUseDefaultName,
+                                drake::systems::BasicVector<T>(2),
                                 &Particle::CopyStateOut);
 }
 

--- a/drake_cmake_installed/src/particles/particle.cc
+++ b/drake_cmake_installed/src/particles/particle.cc
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2017, Massachusetts Institute of Technology.
+ * Copyright (c) 2017-2021, Massachusetts Institute of Technology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,13 @@ namespace particles {
 template <typename T>
 Particle<T>::Particle() {
   // A 1D input vector for acceleration.
-  this->DeclareInputPort(drake::systems::kVectorValued, 1);
+  this->DeclareInputPort(drake::systems::kUseDefaultName,
+                         drake::systems::kVectorValued, 1);
   // Adding one generalized position and one generalized velocity.
   this->DeclareContinuousState(1, 1, 0);
   // A 2D output vector for position and velocity.
-  this->DeclareVectorOutputPort(drake::systems::BasicVector<T>(2),
+  this->DeclareVectorOutputPort(drake::systems::kUseDefaultName,
+                                drake::systems::BasicVector<T>(2),
                                 &Particle::CopyStateOut);
 }
 

--- a/drake_cmake_installed/src/simple_bindings/simple_bindings.cc
+++ b/drake_cmake_installed/src/simple_bindings/simple_bindings.cc
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2018, Toyota Research Institute.
+ * Copyright (c) 2018-2021, Toyota Research Institute.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,9 +55,9 @@ class SimpleAdder : public LeafSystem<T> {
  public:
   explicit SimpleAdder(T add)
       : add_(add) {
-    this->DeclareInputPort(kVectorValued, 1);
+    this->DeclareInputPort("in", kVectorValued, 1);
     this->DeclareVectorOutputPort(
-        BasicVector<T>(1), &SimpleAdder::CalcOutput);
+        "out", BasicVector<T>(1), &SimpleAdder::CalcOutput);
   }
 
  private:

--- a/drake_cmake_installed_apt/src/particle.cc
+++ b/drake_cmake_installed_apt/src/particle.cc
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2021, Massachusetts Institute of Technology.
+ * Copyright (c) 2017-2021, Massachusetts Institute of Technology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,13 @@ namespace particles {
 template <typename T>
 Particle<T>::Particle() {
   // A 1D input vector for acceleration.
-  this->DeclareInputPort(drake::systems::kVectorValued, 1);
+  this->DeclareInputPort(drake::systems::kUseDefaultName,
+                         drake::systems::kVectorValued, 1);
   // Adding one generalized position and one generalized velocity.
   this->DeclareContinuousState(1, 1, 0);
   // A 2D output vector for position and velocity.
-  this->DeclareVectorOutputPort(drake::systems::BasicVector<T>(2),
+  this->DeclareVectorOutputPort(drake::systems::kUseDefaultName,
+                                drake::systems::BasicVector<T>(2),
                                 &Particle::CopyStateOut);
 }
 

--- a/drake_cmake_installed_apt/src/particle.h
+++ b/drake_cmake_installed_apt/src/particle.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2021, Massachusetts Institute of Technology.
+ * Copyright (c) 2017-2021, Massachusetts Institute of Technology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
These overloads will soon be deprecated in Drake.

- https://github.com/RobotLocomotion/drake/pull/15182
- https://github.com/RobotLocomotion/drake/pull/15179

The "particle" example is copied several times within this repository; also make a few edits to keep the copies more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/205)
<!-- Reviewable:end -->
