### PR TITLE
Update deprecated SignalLogger

### DIFF
--- a/drake_bazel_external/apps/simple_adder_py_test.py
+++ b/drake_bazel_external/apps/simple_adder_py_test.py
@@ -43,7 +43,7 @@ from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.primitives import (
     ConstantVectorSource,
-    SignalLogger,
+    VectorLogSink,
 )
 
 
@@ -53,14 +53,14 @@ def main():
     source = builder.AddSystem(ConstantVectorSource([10.]))
     adder = builder.AddSystem(SimpleAdder(100.))
     builder.Connect(source.get_output_port(0), adder.get_input_port(0))
-    logger = builder.AddSystem(SignalLogger(1))
+    logger = builder.AddSystem(VectorLogSink(1))
     builder.Connect(adder.get_output_port(0), logger.get_input_port(0))
     diagram = builder.Build()
 
     simulator = Simulator(diagram)
     simulator.AdvanceTo(1)
 
-    x = logger.data()
+    x = logger.FindLog(simulator.get_context()).data()
     print("Output values: {}".format(x))
     assert np.allclose(x, 110.)
 

--- a/drake_bazel_external/apps/simple_adder_test.cc
+++ b/drake_bazel_external/apps/simple_adder_test.cc
@@ -41,14 +41,14 @@
 #include <drake/systems/analysis/simulator.h>
 #include <drake/systems/framework/diagram_builder.h>
 #include <drake/systems/primitives/constant_vector_source.h>
-#include <drake/systems/primitives/signal_logger.h>
+#include <drake/systems/primitives/vector_log_sink.h>
 
 #include "simple_adder.h"
 
 using drake::systems::Simulator;
 using drake::systems::DiagramBuilder;
 using drake::systems::ConstantVectorSource;
-using drake::systems::SignalLogger;
+using drake::systems::VectorLogSink;
 
 namespace drake_external_examples {
 namespace {
@@ -59,14 +59,14 @@ int DoMain() {
       Eigen::VectorXd::Constant(1, 10.));
   auto adder = builder.AddSystem<SimpleAdder<double>>(100.);
   builder.Connect(source->get_output_port(), adder->get_input_port(0));
-  auto logger = builder.AddSystem<SignalLogger<double>>(1);
+  auto logger = builder.AddSystem<VectorLogSink<double>>(1);
   builder.Connect(adder->get_output_port(0), logger->get_input_port());
   auto diagram = builder.Build();
 
   Simulator<double> simulator(*diagram);
   simulator.AdvanceTo(1);
 
-  auto x = logger->data();
+  auto x = logger->FindLog(simulator.get_context()).data();
   Eigen::VectorXd x_expected = Eigen::Vector2d(110., 110.);
   std::cout << "Output values: " << x << std::endl;
   DRAKE_DEMAND(x.isApprox(x_expected.transpose()));

--- a/drake_bazel_external/apps/simple_logging_example.py
+++ b/drake_bazel_external/apps/simple_logging_example.py
@@ -41,21 +41,21 @@ from pydrake.systems.framework import (
 )
 from pydrake.systems.primitives import (
     ConstantVectorSource,
-    SignalLogger,
+    VectorLogSink,
 )
 
 
 def main():
     builder = DiagramBuilder()
     source = builder.AddSystem(ConstantVectorSource([10.]))
-    logger = builder.AddSystem(SignalLogger(1))
+    logger = builder.AddSystem(VectorLogSink(1))
     builder.Connect(source.get_output_port(0), logger.get_input_port(0))
     diagram = builder.Build()
 
     simulator = Simulator(diagram)
     simulator.AdvanceTo(1)
 
-    x = logger.data()
+    x = logger.FindLog(simulator.get_context()).data()
     print("Output values: {}".format(x))
     assert np.allclose(x, 10.)
 

--- a/drake_bazel_installed/apps/simple_logging_example.py
+++ b/drake_bazel_installed/apps/simple_logging_example.py
@@ -41,21 +41,21 @@ from pydrake.systems.framework import (
 )
 from pydrake.systems.primitives import (
     ConstantVectorSource,
-    SignalLogger,
+    VectorLogSink,
 )
 
 
 def main():
     builder = DiagramBuilder()
     source = builder.AddSystem(ConstantVectorSource([10.]))
-    logger = builder.AddSystem(SignalLogger(1))
+    logger = builder.AddSystem(VectorLogSink(1))
     builder.Connect(source.get_output_port(0), logger.get_input_port(0))
     diagram = builder.Build()
 
     simulator = Simulator(diagram)
     simulator.AdvanceTo(1)
 
-    x = logger.data()
+    x = logger.FindLog(simulator.get_context()).data()
     print("Output values: {}".format(x))
     assert np.allclose(x, 10.)
 

--- a/drake_cmake_installed/src/simple_bindings/simple_bindings_test.py
+++ b/drake_cmake_installed/src/simple_bindings/simple_bindings_test.py
@@ -43,7 +43,7 @@ from pydrake.systems.framework import (
 )
 from pydrake.systems.primitives import (
     ConstantVectorSource,
-    SignalLogger,
+    VectorLogSink,
 )
 
 
@@ -52,14 +52,14 @@ def main():
     source = builder.AddSystem(ConstantVectorSource([10.]))
     adder = builder.AddSystem(SimpleAdder(100.))
     builder.Connect(source.get_output_port(0), adder.get_input_port(0))
-    logger = builder.AddSystem(SignalLogger(1))
+    logger = builder.AddSystem(VectorLogSink(1))
     builder.Connect(adder.get_output_port(0), logger.get_input_port(0))
     diagram = builder.Build()
 
     simulator = Simulator(diagram)
     simulator.AdvanceTo(1)
 
-    x = logger.data()
+    x = logger.FindLog(simulator.get_context()).data()
     print("Output values: {}".format(x))
     assert np.allclose(x, 110.)
 


### PR DESCRIPTION
SingalLogger was deprecated in [Drake Issue 10228](https://github.com/RobotLocomotion/drake/issues/10228).

Replace SignalLogger with VectorLogSink