### PR TITLE
Fix incorrectly set up Drake environment

### DIFF
--- a/drake_cmake_external/CMakeLists.txt
+++ b/drake_cmake_external/CMakeLists.txt
@@ -130,6 +130,22 @@ ExternalProject_Add(spdlog
     -Dfmt_DIR=${CMAKE_INSTALL_PREFIX}/lib/cmake/fmt
 )
 
+# This is the external project PREFIX (not to be confused with the install
+# prefix) which will contain, among other things, the checkout of Drake's
+# source. This should match the default value, but for paranoia's sake, we'll
+# also pass this explicitly to ExternalProject_Add.
+set(DRAKE_PREFIX "${PROJECT_BINARY_DIR}/drake-prefix")
+
+# Location of the platform-specific install_prereqs_user_environment.sh.
+if(APPLE)
+  set(DRAKE_SETUP_DIR "${DRAKE_PREFIX}/src/drake/setup/mac")
+else()
+  set(DRAKE_SETUP_DIR "${DRAKE_PREFIX}/src/drake/setup/ubuntu")
+endif()
+set(DRAKE_INSTALL_PREREQS_USER_ENVIRONMENT
+  "${DRAKE_SETUP_DIR}/source_distribution/install_prereqs_user_environment.sh"
+)
+
 ExternalProject_Add(drake
   DEPENDS eigen fmt spdlog
   URL https://github.com/RobotLocomotion/drake/archive/master.tar.gz
@@ -138,6 +154,7 @@ ExternalProject_Add(drake
   # URL https://github.com/RobotLocomotion/drake/archive/65c4366ea2b63278a286b1e22b8d464d50fbe365.tar.gz
   # URL_HASH SHA256=899d98485522a7cd5251e50a7a6b8a64e40aff2a3af4951a3f0857fd938cafca
   TLS_VERIFY ON
+  PATCH_COMMAND ${DRAKE_INSTALL_PREREQS_USER_ENVIRONMENT}
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
@@ -149,6 +166,7 @@ ExternalProject_Add(drake
     -DWITH_USER_EIGEN:BOOLEAN=ON
     -DWITH_USER_FMT:BOOLEAN=ON
     -DWITH_USER_SPDLOG:BOOLEAN=ON
+  PREFIX "${DRAKE_PREFIX}"
   BINARY_DIR "${PROJECT_BINARY_DIR}/drake"
   BUILD_ALWAYS ON
   INSTALL_COMMAND :


### PR DESCRIPTION
Drake now requires that it's "user environment" Bazel .rc has been created prior to building. Since our examples appear to bypass the usual "install Drake's prerequisites" step, add logic to execute this specific step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/227)
<!-- Reviewable:end -->
