### PR TITLE
Revert "Pin bazel version to 5.2.0"

### DIFF
--- a/scripts/continuous_integration/common/drake_ament_cmake_installed
+++ b/scripts/continuous_integration/common/drake_ament_cmake_installed
@@ -46,6 +46,7 @@ pushd drake_ament_cmake_installed
 colcon build
 colcon test
 
+chmod -R a+w build install log || true
 rm -rf build install log
 
 popd

--- a/scripts/continuous_integration/common/drake_catkin_installed
+++ b/scripts/continuous_integration/common/drake_catkin_installed
@@ -37,6 +37,7 @@ pushd drake_catkin_installed
 
 catkin_make run_tests
 
+chmod -R a+w build devel || true
 rm -rf build devel
 
 popd

--- a/scripts/continuous_integration/common/drake_cmake_external
+++ b/scripts/continuous_integration/common/drake_cmake_external
@@ -48,6 +48,7 @@ ctest -V .
 
 popd
 
+chmod -R a+w build || true
 rm -rf build
 
 popd

--- a/scripts/continuous_integration/common/drake_cmake_installed
+++ b/scripts/continuous_integration/common/drake_cmake_installed
@@ -44,6 +44,7 @@ ctest -V .
 
 popd
 
+chmod -R a+w build || true
 rm -rf build
 
 popd

--- a/scripts/continuous_integration/common/drake_cmake_installed_apt
+++ b/scripts/continuous_integration/common/drake_cmake_installed_apt
@@ -44,6 +44,7 @@ ctest -V .
 
 popd
 
+chmod -R a+w build || true
 rm -rf build
 
 popd

--- a/scripts/setup/linux/ubuntu/focal/install_prereqs
+++ b/scripts/setup/linux/ubuntu/focal/install_prereqs
@@ -84,12 +84,9 @@ apt-key adv --fetch-keys https://bazel.build/bazel-release.pub.gpg
 echo 'deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8' \
   > /etc/apt/sources.list.d/bazel.list
 
-# TODO(drake#17763):  Bazel is pinned here because Bazel 5.3.0 broke the way
-# we do LCM builds.  This should be reverted when Bazel fixes the problem or
-# when Drake finds a workaround to it.
 apt-get update
 apt-get install --no-install-recommends $(cat <<EOF
-  bazel-5.2.0
+  bazel
   clang-format-12
   cmake
   coinor-libclp-dev
@@ -138,8 +135,6 @@ apt-get install --no-install-recommends $(cat <<EOF
   zlib1g-dev
 EOF
 )
-# Symlink "bazel" to the pinned version.  TODO(drake#17763): Don't do this.
-ln -s /usr/bin/bazel-5.2.0 /usr/local/bin/bazel
 
 locale-gen en_US.UTF-8
 


### PR DESCRIPTION
This reverts commit RobotLocomotion/drake-external-examples#235, effectively unpinning us to use the latest stable bazel (5.3.1 as of today).

Also (prior to the revert), fix CI scripts to not choke on cleanup of readonly files, to deal with the mess of https://github.com/bazelbuild/bazel/issues/15616.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/241)
<!-- Reviewable:end -->
