### PR TITLE
Update path to github actions badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Scripts are provided for various CI instances in `scripts/continuous_integration
 | `drake_cmake_external` | - | o |
 | `drake_cmake_installed` | o | o |
 | `drake_cmake_installed_apt` | o | - |
-|| ![GitHub Actions](https://img.shields.io/github/workflow/status/RobotLocomotion/drake-external-examples/ci/main) | [![Jenkins](https://img.shields.io/jenkins/build.svg?jobUrl=https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/job/main)](https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/) |
+|| ![GitHub Actions](https://img.shields.io/github/actions/workflow/status/RobotLocomotion/drake-external-examples/ci.yml?branch=main) | [![Jenkins](https://img.shields.io/jenkins/build.svg?jobUrl=https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/job/main)](https://drake-jenkins.csail.mit.edu/job/RobotLocomotion/job/drake-external-examples/) |
+
 
 Note, the GitHub Actions jobs only build and test `drake_ament_cmake_installed`,
 `drake_bazel_installed`, `drake_catkin_installed`, `drake_cmake_installed`, and


### PR DESCRIPTION
The badge URL for github actions has changed (https://github.com/badges/shields/issues/8671). Update to the new style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-external-examples/253)
<!-- Reviewable:end -->
