### PR TITLE
Add missing dependency on gflags

### DIFF
--- a/scripts/setup/mac/Brewfile
+++ b/scripts/setup/mac/Brewfile
@@ -4,5 +4,6 @@
 tap 'robotlocomotion/director'
 
 brew 'bazel'
+brew 'gflags'
 brew 'robotlocomotion/director/clang-format@9'
 brew 'pkg-config'


### PR DESCRIPTION
Add gflags to the set of macOS dependencies, as it is no longer installed by Drake (see RobotLocomotion/drake#18586). (Linux already, correctly, includes it as a prerequisite.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/256)
<!-- Reviewable:end -->
