### PR TITLE
[ci] Remove macOS image bypasses that no longer work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,44 +45,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      # TODO(#248): On 2022-12-16 there were build failures being unable to
-      # `brew upgrade python@3.10` during setup due to symlinks in
-      # /usr/local/bin.  On 2023-01-03 there were similar failures with the
-      # upgrade of 3.11.0 => 3.11.1.  When python@3.11 becomes the default for
-      # drake, it should be ok to delete the `sanitize brew` step.  An
-      # alternative may be to delete this section when the GHA ticket is solved:
-      # https://github.com/actions/setup-python/issues/577
-      - name: sanitize brew
-        run: |
-          brew unlink python
-          brew unlink python@3.8
-          brew unlink python@3.10
-          brew unlink python@3.11
-
-          # Conflicts that *still* remain (for unknown reasons):
-          # /usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/2to3
-          # /usr/local/bin/idle3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/idle3
-          # /usr/local/bin/pydoc3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/pydoc3
-          # /usr/local/bin/python3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
-          # /usr/local/bin/python3-config -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3-config
-          rm -f /usr/local/bin/2to3
-          rm -f /usr/local/bin/idle3
-          rm -f /usr/local/bin/pydoc3
-          rm -f /usr/local/bin/python3
-          rm -f /usr/local/bin/python3-config
-
-          # New issues related to python@3.11 upgrades.
-          rm -f /usr/local/bin/2to3-3.11
-          rm -f /usr/local/bin/idle3.11
-          rm -f /usr/local/bin/pydoc3.11
-          rm -f /usr/local/bin/python3.11
-          rm -f /usr/local/bin/python3.11-config
-
-          # NOTE: the setup/* scripts eventually trigger `brew upgrade` which
-          # will include these packages, updating now to fail CI earlier.
-          brew update
-          brew upgrade python@3.10
-          brew upgrade python@3.11
       - name: setup
         run: ./scripts/continuous_integration/github_actions/macos_monterey/setup
         shell: zsh -efuo pipefail {0}


### PR DESCRIPTION
GitHub appears to have updated the macOS runners today, python@3.8 is no longer installed.

https://github.com/RobotLocomotion/drake-external-examples/actions/runs/3967407632/jobs/6799332604

Effectively reverts #250, #252.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/257)
<!-- Reviewable:end -->
