### PR TITLE
[ci] Sanitize macOS brew entirely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,20 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      # See issue https://github.com/actions/setup-python/issues/577.  There is
+      # some kind of environment conflict between the symlinks found in the
+      # GitHub Actions runner and `brew upgrade python` where `brew` detects and
+      # refuses to overwrite symlinks.  The cause for our runs is not clear,
+      # we do not use that action, but if that issue is closed this section
+      # can be removed.
+      - name: sanitize brew
+        run: |
+          # Remove the symlinks that cause issues.
+          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+          sudo rm -rf /Library/Frameworks/Python.framework/
+          # Uninstall / reinstall brew.
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       - name: setup
         run: ./scripts/continuous_integration/github_actions/macos_monterey/setup
         shell: zsh -efuo pipefail {0}


### PR DESCRIPTION
Closes: #259.

- Both versions: fixup symlinks as shown in https://github.com/actions/setup-python/issues/577#issuecomment-1386066001
- This version: remove and reinstall `brew`.  Possibly more ideal for our overall environment.  Unclear how stable this is.

Time consideration: GHA has a lot installed via `brew`, [uninstallation took 4 minutes](https://github.com/RobotLocomotion/drake-external-examples/actions/runs/4125328027/jobs/7125736580).  Fixing the symlinks and running upgrade (on today) took [3 minutes 11 seconds](https://github.com/RobotLocomotion/drake-external-examples/actions/runs/4125257574/jobs/7125566031).

Relates: #250, #252, #257.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/260)
<!-- Reviewable:end -->
