### PR TITLE
Cancel previous CI runs when new commits are added to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ on:
       - main
   schedule:
     - cron: '0 12 * * *'
+concurrency:
+  # Cancel previous CI runs when additional commits are added to a pull request.
+  # This will not cancel CI runs associated with `schedule` or `push`.
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   macos_monterey:
     name: macos monterey 12


### PR DESCRIPTION
GitHub Actions running for previous commits will now be halted when new commits are pushed to a pull request.  All runs should continue normally when pushing to `main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/261)
<!-- Reviewable:end -->
