### PR TITLE
Update rcfile advice for force_pic and disable it by default

### DIFF
--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: MIT-0
 
-# Disable native Python rules in Bazel versions before 3.0.
-build --incompatible_load_python_rules_from_bzl=yes
-
 # Default to an optimized build.
 build --compilation_mode=opt
 
 # Default build options.
-build --force_pic=yes
 build --strip=never
 
 # Default test options.
@@ -20,6 +16,11 @@ build --host_cxxopt=-std=c++17
 
 # https://github.com/bazelbuild/bazel/issues/1164
 build --action_env=CCACHE_DISABLE=1
+
+# For Ubuntu builds, this flag can cut build times in half. For macOS builds,
+# this flag might cause build errors. We suggest turning it on if and only if
+# your project doesn't use macOS.
+## build --force_pic=yes
 
 # TODO(jwnimmer-tri) We should see if we can reuse more of Drake's
 # customizations somehow.

--- a/drake_bazel_installed/.bazelrc
+++ b/drake_bazel_installed/.bazelrc
@@ -1,14 +1,9 @@
 # SPDX-License-Identifier: MIT-0
 
-# Disable native Python rules in Bazel versions before 3.0.
-# TODO(jamiesnape): Uncomment the below line when @drake uses @rules_python.
-# build --incompatible_load_python_rules_from_bzl=yes
-
 # Default to an optimized build.
 build --compilation_mode=opt
 
 # Default build options.
-build --force_pic=yes
 build --strip=never
 
 # Default test options.
@@ -21,6 +16,11 @@ build --host_cxxopt=-std=c++17
 
 # https://github.com/bazelbuild/bazel/issues/1164
 build --action_env=CCACHE_DISABLE=1
+
+# For Ubuntu builds, this flag can cut build times in half. For macOS builds,
+# this flag might cause build errors. We suggest turning it on if and only if
+# your project doesn't use macOS.
+## build --force_pic=yes
 
 # TODO(jwnimmer-tri) We should see if we can reuse more of Drake's
 # customizations somehow.

--- a/scripts/continuous_integration/common/drake_bazel_external
+++ b/scripts/continuous_integration/common/drake_bazel_external
@@ -3,10 +3,9 @@
 
 set -euxo pipefail
 
-bazel version
-
 pushd drake_bazel_external
 
+bazel version
 bazel test //...
 
 popd

--- a/scripts/continuous_integration/common/drake_bazel_installed
+++ b/scripts/continuous_integration/common/drake_bazel_installed
@@ -3,10 +3,9 @@
 
 set -euxo pipefail
 
-bazel version
-
 pushd drake_bazel_installed
 
+bazel version
 bazel test //...
 
 popd


### PR DESCRIPTION
While we're here, clean up some other non-functional irregularies:
- Remove irrelevant rules_python flag (https://github.com/bazelbuild/bazel/issues/9006).
- Use the correct working directory during `bazel version`.

Towards https://github.com/RobotLocomotion/drake/issues/20217.

See also https://github.com/RobotLocomotion/drake/pull/20242.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/270)
<!-- Reviewable:end -->
