### PR TITLE
Install Drake when built with CMake

### DIFF
--- a/drake_cmake_external/CMakeLists.txt
+++ b/drake_cmake_external/CMakeLists.txt
@@ -128,7 +128,6 @@ ExternalProject_Add(drake
   PREFIX "${DRAKE_PREFIX}"
   BINARY_DIR "${PROJECT_BINARY_DIR}/drake"
   BUILD_ALWAYS ON
-  INSTALL_COMMAND :
 )
 
 ExternalProject_Add(drake_external_examples


### PR DESCRIPTION
Upstream is changing to make installation not part of the build step. Accordingly, remove logic to suppress the 'install' step for Drake.

See also https://github.com/RobotLocomotion/drake/pull/20916.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/280)
<!-- Reviewable:end -->
