### PR TITLE
[drake_cmake_installed] Change example model path

### DIFF
--- a/drake_cmake_installed/src/find_resource/find_resource_example.cc
+++ b/drake_cmake_installed/src/find_resource/find_resource_example.cc
@@ -13,9 +13,7 @@ namespace drake_external_examples {
 namespace {
 
 int main() {
-  drake::FindResourceOrThrow(
-      "drake/manipulation/models/iiwa_description/urdf/"
-      "iiwa14_primitive_collision.urdf");
+  drake::FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf");
 
   try {
     drake::FindResourceOrThrow("nobody_home.urdf");


### PR DESCRIPTION
The iiwa model is moving into drake_models, so cannot be used as a FindResource demo anymore.

Towards https://github.com/RobotLocomotion/drake/issues/13942.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/289)
<!-- Reviewable:end -->
