### PR TITLE
Test: Look at catkin tests before refactoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
+

--- a/drake_ament_cmake_installed/src/drake_ament_cmake_installed/test/particle_test.cc
+++ b/drake_ament_cmake_installed/src/drake_ament_cmake_installed/test/particle_test.cc
@@ -60,7 +60,7 @@ TYPED_TEST_P(ParticleTest, OutputTest) {
       this->output_->GetMutableVectorData(0);
   // Check results.
   EXPECT_EQ(output_vector->GetAtIndex(0),
-            static_cast<TypeParam>(10.0));  // y0 == x0
+            static_cast<TypeParam>(15.0));  // y0 == x0
   EXPECT_EQ(output_vector->GetAtIndex(1),
             static_cast<TypeParam>(1.0));  // y1 == x1
 }


### PR DESCRIPTION
Testing to see whether the catkin tests ran before the DEE refactoring occurred.

Issue: https://github.com/RobotLocomotion/drake-external-examples/issues/329

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/330)
<!-- Reviewable:end -->
