### PR TITLE
Fix broken ament_cmake link in ament README

### DIFF
--- a/drake_ament_cmake_installed/README.md
+++ b/drake_ament_cmake_installed/README.md
@@ -1,6 +1,6 @@
 # Ament CMake Project with an Installed Drake
 
-This example uses the [`ament_cmake`](https://index.ros.org/doc/ros2/Tutorials/Ament-CMake-Documentation/)
+This example uses the [`ament_cmake`](https://docs.ros.org/en/humble/How-To-Guides/Ament-CMake-Documentation.html)
 build system and [`colcon`](https://colcon.readthedocs.io) command line tool, as
 used by the Robot Operating System (ROS) 2, with an installed instance of the
 Drake [binary packages](https://drake.mit.edu/from_binary.html).


### PR DESCRIPTION
Fixes the ament_cmake link in the drake_ament_cmake_installed README.

Issue: https://github.com/RobotLocomotion/drake-external-examples/issues/310

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/337)
<!-- Reviewable:end -->
