### PR TITLE
Remove unused CTestConfig.cmake

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: MIT-0
-
-set(CTEST_PROJECT_NAME "drake-external-examples")
-set(CTEST_NIGHTLY_START_TIME "00:00:00 EST")
-set(CTEST_DROP_METHOD "https")
-set(CTEST_DROP_SITE "drake-cdash.csail.mit.edu")
-set(CTEST_DROP_LOCATION "/submit.php?project=${CTEST_PROJECT_NAME}")
-set(CTEST_DROP_SITE_CDASH ON)


### PR DESCRIPTION
Configuring CDash submissions is currently not supported by this repository

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/339)
<!-- Reviewable:end -->
