### PR TITLE
Hoist subdir chdir from setup scripts into GHA yaml

### DIFF
--- a/.github/workflows/ament_cmake_installed.yml
+++ b/.github/workflows/ament_cmake_installed.yml
@@ -14,8 +14,10 @@ jobs:
         - name: checkout
           uses: actions/checkout@v4
         - name: setup
-          run: ./drake_ament_cmake_installed/.github/ros_humble_setup
+          working-directory: drake_ament_cmake_installed
+          run: .github/ros_humble_setup
           shell: bash
         - name: ament_cmake_installed build and test
-          run: ./drake_ament_cmake_installed/.github/ci_build_test
+          working-directory: drake_ament_cmake_installed
+          run: .github/ci_build_test
           shell: bash

--- a/.github/workflows/bazel_download.yml
+++ b/.github/workflows/bazel_download.yml
@@ -14,8 +14,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: setup
-        run: ./drake_bazel_download/.github/ubuntu_setup
+        working-directory: drake_bazel_download
+        run: .github/ubuntu_setup
         shell: bash
       - name: bazel_download build and test
-        run: ./drake_bazel_download/.github/ci_build_test
+        working-directory: drake_bazel_download
+        run: .github/ci_build_test
         shell: bash

--- a/.github/workflows/catkin_installed.yml
+++ b/.github/workflows/catkin_installed.yml
@@ -14,8 +14,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: setup
-        run: ./drake_catkin_installed/.github/ubuntu_setup
+        working-directory: drake_catkin_installed
+        run: .github/ubuntu_setup
         shell: bash
       - name: catkin_installed build and test
-        run: ./drake_catkin_installed/.github/ci_build_test
+        working-directory: drake_catkin_installed
+        run: .github/ci_build_test
         shell: bash

--- a/.github/workflows/cmake_installed.yml
+++ b/.github/workflows/cmake_installed.yml
@@ -24,10 +24,12 @@ jobs:
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           sudo rm -rf /Library/Frameworks/Python.framework/
       - name: setup
-        run: ./drake_cmake_installed/setup/install_prereqs
+        working-directory: drake_cmake_installed
+        run: setup/install_prereqs
         shell: zsh -efuo pipefail {0}
       - name: cmake_installed build and test
-        run: ./drake_cmake_installed/.github/ci_build_test
+        working-directory: drake_cmake_installed
+        run: .github/ci_build_test
         shell: zsh -efuo pipefail {0}
   ubuntu_jammy_cmake_installed:
     name: ubuntu 22.04 jammy
@@ -37,8 +39,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: setup
-        run: ./drake_cmake_installed/.github/ubuntu_setup
+        working-directory: drake_cmake_installed
+        run: .github/ubuntu_setup
         shell: bash
       - name: cmake_installed build and test
-        run: ./drake_cmake_installed/.github/ci_build_test
+        working-directory: drake_cmake_installed
+        run: .github/ci_build_test
         shell: bash

--- a/.github/workflows/cmake_installed_apt.yml
+++ b/.github/workflows/cmake_installed_apt.yml
@@ -14,8 +14,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: setup
-        run: ./drake_cmake_installed_apt/.github/ubuntu_apt_setup
+        working-directory: drake_cmake_installed_apt
+        run: .github/ubuntu_apt_setup
         shell: bash
       - name: cmake_installed_apt build and test
-        run: ./drake_cmake_installed_apt/.github/ci_build_test
+        working-directory: drake_cmake_installed_apt
+        run: .github/ci_build_test
         shell: bash

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,13 @@ node('linux-jammy-unprovisioned') {
           stage('checkout') {
             checkout scm
           }
+        }
+        dir('src/drake_bazel_external'){
           stage('bazel_external setup') {
-            sh './drake_bazel_external/.github/setup'
+            sh '.github/setup'
           }
           stage('bazel_external build and test') {
-            sh './drake_bazel_external/.github/ci_build_test'
+            sh '.github/ci_build_test'
           }
         }
       } catch (e) {
@@ -58,11 +60,13 @@ node('linux-jammy-unprovisioned') {
           stage('checkout') {
             checkout scm
           }
+        }
+        dir('src/drake_cmake_external'){
           stage('cmake_external setup') {
-            sh './drake_cmake_external/.github/setup'
+            sh '.github/setup'
           }
           stage('cmake_external build and test') {
-            sh './drake_cmake_external/.github/ci_build_test'
+            sh '.github/ci_build_test'
           }
         }
       } catch (e) {

--- a/drake_ament_cmake_installed/.github/ci_build_test
+++ b/drake_ament_cmake_installed/.github/ci_build_test
@@ -13,12 +13,8 @@ set -xu
 
 cmake --version
 
-pushd drake_ament_cmake_installed
-
 colcon build
 colcon test
 
 chmod -R a+w build install log || true
 rm -rf build install log
-
-popd

--- a/drake_ament_cmake_installed/.github/ros_humble_setup
+++ b/drake_ament_cmake_installed/.github/ros_humble_setup
@@ -8,5 +8,4 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-cd $(dirname "${BASH_SOURCE}")/..
 setup/install_prereqs --ros-humble

--- a/drake_bazel_download/.github/ci_build_test
+++ b/drake_bazel_download/.github/ci_build_test
@@ -3,9 +3,5 @@
 
 set -euxo pipefail
 
-pushd drake_bazel_download
-
 bazel version
 bazel test //...
-
-popd

--- a/drake_bazel_download/.github/ubuntu_setup
+++ b/drake_bazel_download/.github/ubuntu_setup
@@ -8,5 +8,4 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-cd $(dirname "${BASH_SOURCE}")/..
 setup/install_prereqs

--- a/drake_bazel_external/.github/ci_build_test
+++ b/drake_bazel_external/.github/ci_build_test
@@ -3,9 +3,5 @@
 
 set -euxo pipefail
 
-pushd drake_bazel_external
-
 bazel version
 bazel test //...
-
-popd

--- a/drake_bazel_external/.github/setup
+++ b/drake_bazel_external/.github/setup
@@ -3,8 +3,7 @@
 
 set -euxo pipefail
 
-cd $(dirname "${BASH_SOURCE}")
-sudo ./ubuntu_setup
+sudo .github/ubuntu_setup
 
 cat > "${HOME}/.bazelrc" << EOF
 startup --output_user_root=${WORKSPACE}/_bazel_${USER}

--- a/drake_bazel_external/.github/ubuntu_setup
+++ b/drake_bazel_external/.github/ubuntu_setup
@@ -8,5 +8,4 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-cd $(dirname "${BASH_SOURCE}")/..
 setup/install_prereqs

--- a/drake_catkin_installed/.github/ci_build_test
+++ b/drake_catkin_installed/.github/ci_build_test
@@ -5,11 +5,7 @@ set -euxo pipefail
 
 cmake --version
 
-pushd drake_catkin_installed
-
 catkin_make run_tests
 
 chmod -R a+w build devel || true
 rm -rf build devel
-
-popd

--- a/drake_catkin_installed/.github/ubuntu_setup
+++ b/drake_catkin_installed/.github/ubuntu_setup
@@ -8,5 +8,4 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-cd $(dirname "${BASH_SOURCE}")/..
 setup/install_prereqs

--- a/drake_cmake_external/.github/ci_build_test
+++ b/drake_cmake_external/.github/ci_build_test
@@ -5,8 +5,6 @@ set -euxo pipefail
 
 cmake --version
 
-pushd drake_cmake_external
-
 mkdir build
 pushd build
 
@@ -22,5 +20,3 @@ popd
 
 chmod -R a+w build || true
 rm -rf build
-
-popd

--- a/drake_cmake_external/.github/setup
+++ b/drake_cmake_external/.github/setup
@@ -3,8 +3,7 @@
 
 set -euxo pipefail
 
-cd $(dirname "${BASH_SOURCE}")
-sudo ./ubuntu_setup
+sudo .github/ubuntu_setup
 
 cat > "${HOME}/.bazelrc" << EOF
 startup --output_user_root=${WORKSPACE}/_bazel_${USER}

--- a/drake_cmake_external/.github/ubuntu_setup
+++ b/drake_cmake_external/.github/ubuntu_setup
@@ -8,5 +8,4 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-cd $(dirname "${BASH_SOURCE}")/..
 setup/install_prereqs

--- a/drake_cmake_installed/.github/ci_build_test
+++ b/drake_cmake_installed/.github/ci_build_test
@@ -5,8 +5,6 @@ set -euxo pipefail
 
 cmake --version
 
-pushd drake_cmake_installed
-
 mkdir build
 pushd build
 
@@ -18,5 +16,3 @@ popd
 
 chmod -R a+w build || true
 rm -rf build
-
-popd

--- a/drake_cmake_installed/.github/ubuntu_setup
+++ b/drake_cmake_installed/.github/ubuntu_setup
@@ -8,5 +8,4 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-cd $(dirname "${BASH_SOURCE}")/..
 setup/install_prereqs

--- a/drake_cmake_installed_apt/.github/ci_build_test
+++ b/drake_cmake_installed_apt/.github/ci_build_test
@@ -5,8 +5,6 @@ set -euxo pipefail
 
 cmake --version
 
-pushd drake_cmake_installed_apt
-
 mkdir build
 pushd build
 
@@ -18,5 +16,3 @@ popd
 
 chmod -R a+w build || true
 rm -rf build
-
-popd


### PR DESCRIPTION
The scripts shouldn't be copy-pasting their own project name.

---

This commit was carved out of #333, authored by @nicolecheetham.  We should land the straightforward and uncontroversial boilerplate refactoring separately from the new-feature pieces, not only as a general best practice but because the refatoring is holding up related pull requests like #341.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/342)
<!-- Reviewable:end -->
