### PR TITLE
[drake_cmake_external] Strenthen CI by removing unnecessary prereqs

### DIFF
--- a/drake_cmake_external/.github/setup
+++ b/drake_cmake_external/.github/setup
@@ -8,3 +8,9 @@ sudo .github/ubuntu_setup
 
 # drake source setup
 setup/install_prereqs
+
+# Provide regression coverage for the WITH_USER_...=ON options by un-installing
+# packages that should not be necessary in this particular build flavor. This
+# example configures them to be built from source.
+sudo apt-get remove libeigen3-dev libfmt-dev libspdlog-dev
+sudo apt-get autoremove

--- a/private/test/file_sync_test.py
+++ b/private/test/file_sync_test.py
@@ -50,10 +50,6 @@ COPIES = (
         "drake_bazel_external/.github/ci_build_test",
     ),
     (
-        "drake_bazel_external/.github/setup",
-        "drake_cmake_external/.github/setup",
-    ),
-    (
         "drake_bazel_external/.github/ubuntu_setup",
         "drake_cmake_external/.github/ubuntu_setup",
     ),


### PR DESCRIPTION
This will help ensure that the CMake changes in https://github.com/RobotLocomotion/drake/pull/22338 do not break downstream users, by ensuring that the only copies of {eigen, fmt, spdlog} on the CI machine are the custom ones built by CMake and found with `find_package` -- if the CMake plumbing doesn't work, then the example will fail to compile.

Towards https://github.com/RobotLocomotion/drake/issues/20731.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/347)
<!-- Reviewable:end -->
