### PR TITLE
Change Drake installs from /opt to $HOME

### DIFF
--- a/drake_bazel_download/README.md
+++ b/drake_bazel_download/README.md
@@ -8,7 +8,7 @@ For an introduction to Bazel, refer to
 
 ## Instructions
 
-First, run the `install_prereqs` script to download the Drake source to `/opt/drake/`.
+First, run the `install_prereqs` script to download the Drake source to `$HOME/drake/`.
 This also runs Drake's setup script to install the required Ubuntu packages:
 
 ```bash

--- a/drake_bazel_download/setup/install_prereqs
+++ b/drake_bazel_download/setup/install_prereqs
@@ -53,9 +53,9 @@ EOF
 wget -O drake.tar.gz \
   https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz
 trap 'rm -f drake.tar.gz' EXIT
-tar -xf drake.tar.gz -C /opt
+tar -xf drake.tar.gz -C $HOME
 
 # Show version for debugging; use echo for newline / readability.
-echo -e "\ndrake VERSION.TXT: $(cat /opt/drake/share/doc/drake/VERSION.TXT)\n"
+echo -e "\ndrake VERSION.TXT: $(cat $HOME/drake/share/doc/drake/VERSION.TXT)\n"
 
-/opt/drake/share/drake/setup/install_prereqs
+$HOME/drake/share/drake/setup/install_prereqs

--- a/drake_bazel_download/setup/install_prereqs
+++ b/drake_bazel_download/setup/install_prereqs
@@ -50,6 +50,7 @@ apt-get install --no-install-recommends $(cat <<EOF
 EOF
 )
 
+# Download the drake source
 wget -O drake.tar.gz \
   https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz
 trap 'rm -f drake.tar.gz' EXIT
@@ -58,4 +59,5 @@ tar -xf drake.tar.gz -C $HOME
 # Show version for debugging; use echo for newline / readability.
 echo -e "\ndrake VERSION.TXT: $(cat $HOME/drake/share/doc/drake/VERSION.TXT)\n"
 
+# Install the source prereqs
 $HOME/drake/share/drake/setup/install_prereqs

--- a/drake_cmake_installed/.github/ci_build_test
+++ b/drake_cmake_installed/.github/ci_build_test
@@ -8,7 +8,7 @@ cmake --version
 mkdir build
 pushd build
 
-cmake -DCMAKE_PREFIX_PATH=/opt/drake "$@" ..
+cmake -DCMAKE_PREFIX_PATH=$HOME/drake "$@" ..
 make
 ctest -V .
 

--- a/drake_cmake_installed/README.md
+++ b/drake_cmake_installed/README.md
@@ -8,31 +8,31 @@ These instructions are only supported for Ubuntu 22.04 (Jammy).
 
 ```bash
 ###############################################################
-# Install Prerequisites
+# Download Drake and Install Prerequisites
 ###############################################################
 
-# Download Drake source to /opt/drake/ and install
-# various system dependencies
+# Download Drake source to $HOME/drake/ and
+# install various system dependencies
 sudo setup/install_prereqs
 
 ###############################################################
-# Install Drake to $HOME/drake
+# Alternative Drake Versions
 ###############################################################
 
-# There are a few options to install drake:
+# The script above gets the latest version of Drake (usually
+# last night's build). Ignore this step if that version is desired.
+# Otherwise, the following are alternative options for which
+# version of Drake to download:
 
 # 1) A specific version (date-stamped)
 curl -O https://drake-packages.csail.mit.edu/drake/nightly/drake-20240214-jammy.tar.gz
+tar -xvzf drake-20240214-jammy.tar.gz -C $HOME
 
-# 2) The latest (usually last night's build)
-curl -O https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz
-tar -xvzf drake-latest-jammy.tar.gz -C $HOME
-
-# 3) Manual Installation
+# 2) Manual Installation
 git clone https://github.com/RobotLocomotion/drake.git
 (cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake .. && make)
 
-# 4) Manual Installation w/ Licensed Gurobi
+# 3) Manual Installation w/ Licensed Gurobi
 # Install & setup gurobi (http://drake.mit.edu/bazel.html?highlight=gurobi#install-on-ubuntu)
 git clone https://github.com/RobotLocomotion/drake.git
 (cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake -DWITH_GUROBI=ON .. && make)

--- a/drake_cmake_installed/setup/install_prereqs
+++ b/drake_cmake_installed/setup/install_prereqs
@@ -39,17 +39,17 @@ case "$OSTYPE" in
       exit 1
     fi
 
-    if [[ ! -d /opt/drake ]]; then
-      sudo mkdir -p /opt/drake
-      sudo chmod g+rwx /opt/drake
-      sudo chown "${USER}" /opt/drake
-      sudo chgrp admin /opt/drake
+    if [[ ! -d "${HOME}/drake" ]]; then
+      sudo mkdir -p "${HOME}/drake"
+      sudo chmod g+rwx "${HOME}/drake"
+      sudo chown "${USER}" "${HOME}/drake"
+      sudo chgrp admin "${HOME}/drake"
     fi
 
     # Install Drake dependencies.
     curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz
     trap 'rm -f drake.tar.gz' EXIT
-    tar -xf drake.tar.gz -C /opt
+    tar -xf drake.tar.gz -C $HOME
     ;;
 
     linux*)
@@ -76,7 +76,7 @@ EOF
     wget -O drake.tar.gz \
       https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz
     trap 'rm -f drake.tar.gz' EXIT
-    tar -xf drake.tar.gz -C /opt
+    tar -xf drake.tar.gz -C $HOME
 
     apt-get update
     apt-get install --no-install-recommends $(cat <<EOF
@@ -87,6 +87,6 @@ EOF
 esac
 
 # Show version for debugging; use echo for newline / readability.
-echo -e "\ndrake VERSION.TXT: $(cat /opt/drake/share/doc/drake/VERSION.TXT)\n"
+echo -e "\ndrake VERSION.TXT: $(cat $HOME/drake/share/doc/drake/VERSION.TXT)\n"
 
-/opt/drake/share/drake/setup/install_prereqs
+$HOME/drake/share/drake/setup/install_prereqs

--- a/drake_cmake_installed/setup/install_prereqs
+++ b/drake_cmake_installed/setup/install_prereqs
@@ -39,13 +39,6 @@ case "$OSTYPE" in
       exit 1
     fi
 
-    if [[ ! -d "${HOME}/drake" ]]; then
-      sudo mkdir -p "${HOME}/drake"
-      sudo chmod g+rwx "${HOME}/drake"
-      sudo chown "${USER}" "${HOME}/drake"
-      sudo chgrp admin "${HOME}/drake"
-    fi
-
     # Download the drake source
     curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz
     trap 'rm -f drake.tar.gz' EXIT

--- a/drake_cmake_installed/setup/install_prereqs
+++ b/drake_cmake_installed/setup/install_prereqs
@@ -46,7 +46,7 @@ case "$OSTYPE" in
       sudo chgrp admin "${HOME}/drake"
     fi
 
-    # Install Drake dependencies.
+    # Download the drake source
     curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz
     trap 'rm -f drake.tar.gz' EXIT
     tar -xf drake.tar.gz -C $HOME
@@ -73,6 +73,7 @@ case "$OSTYPE" in
 EOF
     )
 
+    # Download the drake source
     wget -O drake.tar.gz \
       https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz
     trap 'rm -f drake.tar.gz' EXIT
@@ -89,4 +90,5 @@ esac
 # Show version for debugging; use echo for newline / readability.
 echo -e "\ndrake VERSION.TXT: $(cat $HOME/drake/share/doc/drake/VERSION.TXT)\n"
 
+# Install the source prereqs
 $HOME/drake/share/drake/setup/install_prereqs


### PR DESCRIPTION
This is a follow-up to #357. It was originally addressed in #258, but `/opt` still lives inside `drake_bazel_download` and `drake_cmake_installed`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/363)
<!-- Reviewable:end -->
