### PR TITLE
Slack integration for GHA failures (build cop)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,3 @@ jobs:
           python-version: '3.12'
       - name: file_sync test
         run: python ./private/test/file_sync_test.py
-  slack_test_fail:
-    runs-on: ubuntu-latest
-    steps:
-      - name: fail step
-        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,8 @@ jobs:
           python-version: '3.12'
       - name: file_sync test
         run: python ./private/test/file_sync_test.py
+  slack_test_fail:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail step
+        run: exit 1

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT-0
+
+---
+name: slack
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Build Cop Slack
+        if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ github.event.workflow_run.conclusion }}
+          notification_title: >
+            ${{github.event.workflow_run.name}} failed on ${{github.event.workflow_run.head_branch}} -
+            <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>
+          message_format: |
+            Result: ${{github.event.workflow_run.conclusion}}
+            Run: ${{github.event.workflow_run.run_number}}
+            Branch: <${{github.server_url}}/${{github.repository}}/tree/${{github.event.workflow_run.head_branch}}|${{github.repository}}/${{github.event.workflow_run.head_branch}}>
+          footer: "Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILDCOP_URL }}

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -8,21 +8,20 @@ on:
     types: [completed]
 
 jobs:
-  notify:
+  notify_failure:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Build Cop Slack
-        if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+      - name: Buildcop Notify Failure
+        if: ${{ github.event.workflow_run.conclusion }} == 'failure' || ${{ github.event.workflow_run.conclusion }} == 'timed_out'
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ github.event.workflow_run.conclusion }}
           notification_title: >
-            ${{github.event.workflow_run.name}} failed on ${{github.event.workflow_run.head_branch}} -
+            ${{github.event.workflow_run.name}} ${{github.event.workflow_run.conclusion}} on {branch} -
             <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>
           message_format: |
-            Result: ${{github.event.workflow_run.conclusion}}
             Run: ${{github.event.workflow_run.run_number}}
-            Branch: <${{github.server_url}}/${{github.repository}}/tree/${{github.event.workflow_run.head_branch}}|${{github.repository}}/${{github.event.workflow_run.head_branch}}>
-          footer: "Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>"
+            Branch: <{branch_url}|{branch}>
+          footer: "Repository: <{repo_url}|{repo}>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILDCOP_URL }}


### PR DESCRIPTION
Addresses [#22019](https://github.com/RobotLocomotion/drake/issues/22019). Adds CI workflow for a custom Slack bot in DrakeDevelopers to send a notification to the `#buildcop` channel when GitHub Actions fails.

* The Slack workflow in CI is triggered when the main CI workflow finishes, and the "send notification" step happens when the main CI workflow failed (or timed out).
* The message is formatted as follows (save for the "test" names), with links to the failed run, the branch, and the repository:
* The Slack "app" (bot) that is running this, GitHub Actions Build Cop, is installed to the DrakeDevelopers workspace. I've added @jwnimmer-tri and @BetsyMcPhail as collaborators so that changes can be made as needed.

![image](https://github.com/user-attachments/assets/561f8290-eeb3-4eea-b5fd-833c9e6ac0b4)

It turns out that GitHub's Slack [integration](https://github.com/integrations/slack) doesn't support only filtering for workflow failures (see: https://github.com/integrations/slack/issues/1563), which is why we're using the [notify-slack-action](https://github.com/ravsamhq/notify-slack-action) instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/366)
<!-- Reviewable:end -->
