### PR TITLE
Update drake_cmake_installed README

### DIFF
--- a/drake_cmake_installed/README.md
+++ b/drake_cmake_installed/README.md
@@ -20,8 +20,7 @@ Drake to download.
 
 ## Build Everything
 
-Then, after cloning this repository, run the following to
-build using CMake from the current directory
+Then run the following to build using CMake from the current directory
 (`drake-external-examples/drake_cmake_installed`):
 
 ```bash
@@ -38,6 +37,10 @@ By default, `install_prereqs` script gets the latest version
 of Drake (usually last night's build). Ignore this if that
 version is desired. Otherwise, the following are alternative
 options for which version of Drake to download.
+
+To use any of these options, instead of running `install_prereqs`,
+first run the code for whichever option you prefer below. Each option
+downloads Drake to the `$HOME` directory.
 
 1. A specific version (date-stamped)
 
@@ -59,6 +62,15 @@ Install & setup gurobi (http://drake.mit.edu/bazel.html?highlight=gurobi#install
 ```bash
 git clone https://github.com/RobotLocomotion/drake.git
 (cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake -DWITH_GUROBI=ON .. && make)
+```
+
+Then ensure you have Python installed; specifically,
+install `python3-all-dev` if on Ubuntu, and use Homebrew Python
+(not Apple's system Python) if on macOS. Finally, run *Drake's*
+`install_prereqs` script to install the remaining system packages:
+
+```bash
+$HOME/drake/share/drake/setup/install_prereqs
 ```
 
 # Examples

--- a/drake_cmake_installed/README.md
+++ b/drake_cmake_installed/README.md
@@ -39,39 +39,50 @@ version is desired. Otherwise, the following are alternative
 options for which version of Drake to download.
 
 To use any of these options, instead of running `install_prereqs`,
-first run the code for whichever option you prefer below. Each option
+run the code for whichever option you prefer below. Each option
 downloads Drake to the `$HOME` directory.
 
 1. A specific version (date-stamped)
 
+Replace `jammy` (for Ubuntu 22.04) with `noble` or `mac-arm64`
+to download the version needed for your operating system.
+
 ```bash
-curl -O https://drake-packages.csail.mit.edu/drake/nightly/drake-20240214-jammy.tar.gz
-tar -xvzf drake-20240214-jammy.tar.gz -C $HOME
+curl -O https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250131-jammy.tar.gz
+tar -xvzf drake-0.0.20250131-jammy.tar.gz -C $HOME
+$HOME/drake/share/drake/setup/install_prereqs # install prereqs
 ```
+
+See [Installation via Direct Download](https://drake.mit.edu/from_binary.html)
+for more information.
 
 2. Manual installation
 
+If on Mac, adjust the call to install prereqs to replace `ubuntu` with `mac`
+and remove the use of `sudo`.
+
 ```bash
 git clone https://github.com/RobotLocomotion/drake.git
-(cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake .. && make)
+cd drake
+sudo setup/ubuntu/source_distribution/install_prereqs.sh # install prereqs
+(mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake .. && make)
 ```
 
 3. Manual installation w/ licensed Gurobi
 Install & setup gurobi (http://drake.mit.edu/bazel.html?highlight=gurobi#install-on-ubuntu)
 
+If on Mac, adjust the call to install prereqs to replace `ubuntu` with `mac`
+and remove the use of `sudo`.
+
 ```bash
 git clone https://github.com/RobotLocomotion/drake.git
-(cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake -DWITH_GUROBI=ON .. && make)
+cd drake
+sudo setup/ubuntu/source_distribution/install_prereqs.sh # install prereqs
+(mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake -DWITH_GUROBI=ON .. && make)
 ```
 
-Then ensure you have Python installed; specifically,
-install `python3-all-dev` if on Ubuntu, and use Homebrew Python
-(not Apple's system Python) if on macOS. Finally, run *Drake's*
-`install_prereqs` script to install the remaining system packages:
-
-```bash
-$HOME/drake/share/drake/setup/install_prereqs
-```
+Finally, for the code in this example, ensure you have `python3-all-dev`
+installed if on Ubuntu.
 
 # Examples
 

--- a/drake_cmake_installed/README.md
+++ b/drake_cmake_installed/README.md
@@ -4,51 +4,61 @@ This uses the CMake `find_package(drake)` mechanism to find an installed instanc
 
 # Instructions
 
-These instructions are only supported for Ubuntu 22.04 (Jammy).
+## Download and Install Prerequisites
+
+First, run the `install_prereqs` script to download the
+Drake source to `$HOME/drake/`. This also run's Drake's
+setup script to install the required packages depending
+on your operating system:
 
 ```bash
-###############################################################
-# Download Drake and Install Prerequisites
-###############################################################
+setup/install_prereqs
+```
 
-# Download Drake source to $HOME/drake/ and
-# install various system dependencies
-sudo setup/install_prereqs
+See [below](#alternative-versions) for alternative versions of
+Drake to download.
 
-###############################################################
-# Alternative Drake Versions
-###############################################################
+## Build Everything
 
-# The script above gets the latest version of Drake (usually
-# last night's build). Ignore this step if that version is desired.
-# Otherwise, the following are alternative options for which
-# version of Drake to download:
+Then, after cloning this repository, run the following to
+build using CMake from the current directory
+(`drake-external-examples/drake_cmake_installed`):
 
-# 1) A specific version (date-stamped)
-curl -O https://drake-packages.csail.mit.edu/drake/nightly/drake-20240214-jammy.tar.gz
-tar -xvzf drake-20240214-jammy.tar.gz -C $HOME
-
-# 2) Manual Installation
-git clone https://github.com/RobotLocomotion/drake.git
-(cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake .. && make)
-
-# 3) Manual Installation w/ Licensed Gurobi
-# Install & setup gurobi (http://drake.mit.edu/bazel.html?highlight=gurobi#install-on-ubuntu)
-git clone https://github.com/RobotLocomotion/drake.git
-(cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake -DWITH_GUROBI=ON .. && make)
-
-###############################################################
-# Build Everything
-###############################################################
-
-git clone https://github.com/RobotLocomotion/drake-external-examples.git
-cd drake-external-examples/drake_cmake_installed
+```bash
 mkdir build && cd build
 cmake -DCMAKE_PREFIX_PATH=$HOME/drake ..
 make
+```
 
-# (Optionally) Run Tests
-make test
+You can also optionally run the tests by calling `make test`.
+
+## Alternative Versions
+
+By default, `install_prereqs` script gets the latest version
+of Drake (usually last night's build). Ignore this if that
+version is desired. Otherwise, the following are alternative
+options for which version of Drake to download.
+
+1. A specific version (date-stamped)
+
+```bash
+curl -O https://drake-packages.csail.mit.edu/drake/nightly/drake-20240214-jammy.tar.gz
+tar -xvzf drake-20240214-jammy.tar.gz -C $HOME
+```
+
+2. Manual installation
+
+```bash
+git clone https://github.com/RobotLocomotion/drake.git
+(cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake .. && make)
+```
+
+3. Manual installation w/ licensed Gurobi
+Install & setup gurobi (http://drake.mit.edu/bazel.html?highlight=gurobi#install-on-ubuntu)
+
+```bash
+git clone https://github.com/RobotLocomotion/drake.git
+(cd drake && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake -DWITH_GUROBI=ON .. && make)
 ```
 
 # Examples

--- a/drake_cmake_installed/README.md
+++ b/drake_cmake_installed/README.md
@@ -1,6 +1,7 @@
 # CMake Project with an Installed Drake
 
-This uses the CMake `find_package(drake)` mechanism to find an installed instance of Drake.
+This uses the CMake `find_package(drake)`
+mechanism to find an installed instance of Drake.
 
 # Instructions
 
@@ -50,7 +51,7 @@ to download the version needed for your operating system.
 ```bash
 curl -O https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250131-jammy.tar.gz
 tar -xvzf drake-0.0.20250131-jammy.tar.gz -C $HOME
-$HOME/drake/share/drake/setup/install_prereqs # install prereqs
+$HOME/drake/share/drake/setup/install_prereqs
 ```
 
 See [Installation via Direct Download](https://drake.mit.edu/from_binary.html)
@@ -58,26 +59,20 @@ for more information.
 
 2. Manual installation
 
-If on Mac, adjust the call to install prereqs to replace `ubuntu` with `mac`
-and remove the use of `sudo`.
-
 ```bash
 git clone https://github.com/RobotLocomotion/drake.git
 cd drake
-sudo setup/ubuntu/source_distribution/install_prereqs.sh # install prereqs
+setup/install_prereqs
 (mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake .. && make)
 ```
 
 3. Manual installation w/ licensed Gurobi
 Install & setup gurobi (http://drake.mit.edu/bazel.html?highlight=gurobi#install-on-ubuntu)
 
-If on Mac, adjust the call to install prereqs to replace `ubuntu` with `mac`
-and remove the use of `sudo`.
-
 ```bash
 git clone https://github.com/RobotLocomotion/drake.git
 cd drake
-sudo setup/ubuntu/source_distribution/install_prereqs.sh # install prereqs
+setup/install_prereqs
 (mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$HOME/drake -DWITH_GUROBI=ON .. && make)
 ```
 


### PR DESCRIPTION
Addresses [#22040](https://github.com/RobotLocomotion/drake/issues/22040) with the following:

* removes "only supported for Ubuntu 22.04" from `drake_cmake_installed` example
* refactors the README to have a style consistent to the other examples (interspersed text with code, rather than comments)

The `install_prereqs` script in this example was already working with macOS, verified locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/367)
<!-- Reviewable:end -->
