### PR TITLE
[CI Testing] Add manual GHA triggers for Drake PRs

### DIFF
--- a/.github/workflows/bazel_download.yml
+++ b/.github/workflows/bazel_download.yml
@@ -15,7 +15,12 @@ jobs:
         uses: actions/checkout@v4
       - name: setup
         working-directory: drake_bazel_download
-        run: .github/ubuntu_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+          fi
+          .github/ubuntu_setup "${args[@]}"
         shell: bash
       - name: install_bazelisk
         working-directory: drake_bazel_download
@@ -23,5 +28,10 @@ jobs:
         shell: bash
       - name: bazel_download build and test
         working-directory: drake_bazel_download
-        run: .github/ci_build_test
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=(--override-repository)
+          fi
+          .github/ci_build_test "${args[@]}"
         shell: bash

--- a/.github/workflows/bazel_download.yml
+++ b/.github/workflows/bazel_download.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
+            args+=(--package-url ${{ github.event.inputs.linux_jammy_package_tar }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash
@@ -31,7 +31,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--override-repository)
+            args+=(--drake-override)
           fi
           .github/ci_build_test "${args[@]}"
         shell: bash

--- a/.github/workflows/bazel_download.yml
+++ b/.github/workflows/bazel_download.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ on:
         description: 'Full URL for the Drake mac-arm-sonoma-*-experimental-packaging artifact'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz'
+      linux_jammy_wheel_experimental:
+        description: 'Full URL for the Drake linux-jammy-*-wheel-experimental-release artifact (Python 3.10)'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_35_x86_64.whl'
+      mac_arm_sonoma_wheel_experimental:
+        description: 'Full URL for the Drake mac-arm-sonoma-*-wheel-experimental-release artifact (Python 3.12)'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp312-cp312-macosx_14_0_arm64.whl'
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+    inputs:
+      linux_jammy_experimental_packaging:
+        description: 'Full URL for the Drake linux-jammy-*-experimental-packaging artifact'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz'
+      mac_arm_sonoma_experimental_packaging:
+        description: 'Full URL for the Drake mac-arm-sonoma-*-experimental-packaging artifact'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz'
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,20 +13,24 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
-      linux_jammy_experimental_packaging:
-        description: 'Full URL for the Drake linux-jammy-*-experimental-packaging artifact'
+      linux_jammy_package_tar:
+        description: 'Drake linux-jammy-*-packaging .tar.gz artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz'
-      mac_arm_sonoma_experimental_packaging:
-        description: 'Full URL for the Drake mac-arm-sonoma-*-experimental-packaging artifact'
+      linux_jammy_package_deb:
+        description: 'Drake linux-jammy-*-packaging .deb artifact URL'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-jammy.deb'
+      mac_arm_sonoma_package_tar:
+        description: 'Drake mac-arm-sonoma-*-packaging .tar.gz artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz'
-      linux_jammy_wheel_experimental:
-        description: 'Full URL for the Drake linux-jammy-*-wheel-experimental-release artifact (Python 3.10)'
+      linux_jammy_wheel:
+        description: 'Drake linux-jammy-*-wheel-*-release Python 3.10 artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_35_x86_64.whl'
-      mac_arm_sonoma_wheel_experimental:
-        description: 'Full URL for the Drake mac-arm-sonoma-*-wheel-experimental-release artifact (Python 3.12)'
+      mac_arm_sonoma_wheel:
+        description: 'Drake mac-arm-sonoma-*-wheel-*-release Python 3.12 artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp312-cp312-macosx_14_0_arm64.whl'
 concurrency:

--- a/.github/workflows/cmake_installed.yml
+++ b/.github/workflows/cmake_installed.yml
@@ -25,7 +25,12 @@ jobs:
           sudo rm -rf /Library/Frameworks/Python.framework/
       - name: setup
         working-directory: drake_cmake_installed
-        run: setup/install_prereqs
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }}")
+          fi
+          setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
       - name: cmake_installed build and test
         working-directory: drake_cmake_installed
@@ -40,7 +45,12 @@ jobs:
         uses: actions/checkout@v4
       - name: setup
         working-directory: drake_cmake_installed
-        run: .github/ubuntu_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+          fi
+          .github/ubuntu_setup "${args[@]}"
         shell: bash
       - name: cmake_installed build and test
         working-directory: drake_cmake_installed

--- a/.github/workflows/cmake_installed.yml
+++ b/.github/workflows/cmake_installed.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }})
+            args+=(--package-url ${{ github.event.inputs.mac_arm_sonoma_package_tar }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -48,7 +48,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
+            args+=(--package-url ${{ github.event.inputs.linux_jammy_package_tar }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/.github/workflows/cmake_installed.yml
+++ b/.github/workflows/cmake_installed.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }}")
+            args+=(--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -48,7 +48,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/.github/workflows/cmake_installed_apt.yml
+++ b/.github/workflows/cmake_installed_apt.yml
@@ -15,7 +15,12 @@ jobs:
         uses: actions/checkout@v4
       - name: setup
         working-directory: drake_cmake_installed_apt
-        run: .github/ubuntu_apt_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=(--package-url ${{ github.event.inputs.linux_jammy_package_deb }})
+          fi
+          .github/ubuntu_apt_setup "${args[@]}"
         shell: bash
       - name: cmake_installed_apt build and test
         working-directory: drake_cmake_installed_apt

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -29,7 +29,12 @@ jobs:
           python-version: '3.12'
       - name: venv setup and install
         working-directory: drake_pip
-        run: setup/setup_env 3.12
+        run: |
+          args=("--python-version '3.12'")
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+          fi
+          setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
       - name: pip build and test
         working-directory: drake_pip
@@ -44,7 +49,12 @@ jobs:
         uses: actions/checkout@v4
       - name: pip setup
         working-directory: drake_pip
-        run: .github/ubuntu_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+          fi
+          .github/ubuntu_setup "${args[@]}"
         shell: bash
       - name: pip build and test
         working-directory: drake_pip

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -30,9 +30,9 @@ jobs:
       - name: venv setup and install
         working-directory: drake_pip
         run: |
-          args=("--python-version '3.12'")
+          args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
           fi
           setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
@@ -52,7 +52,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sonoma_wheel }})
           fi
           setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
@@ -52,7 +52,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.linux_jammy_wheel }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -31,7 +31,11 @@ jobs:
         working-directory: drake_poetry
         run: |
           .github/setup
-          setup/install_prereqs 3.12
+          args=("--python-version '3.12'")
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+          fi
+          setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
       - name: poetry test
         working-directory: drake_poetry
@@ -52,6 +56,10 @@ jobs:
         run: |
           .github/setup
           source $HOME/.profile
-          setup/install_prereqs
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+          fi
+          setup/install_prereqs "${args[@]}"
           .github/ci_build_test
         shell: bash

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -31,9 +31,9 @@ jobs:
         working-directory: drake_poetry
         run: |
           .github/setup
-          args=("--python-version '3.12'")
+          args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -58,7 +58,7 @@ jobs:
           source $HOME/.profile
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
           fi
           setup/install_prereqs "${args[@]}"
           .github/ci_build_test

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -33,7 +33,7 @@ jobs:
           .github/setup
           args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sonoma_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -58,7 +58,7 @@ jobs:
           source $HOME/.profile
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.linux_jammy_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
           .github/ci_build_test

--- a/drake_bazel_download/.github/ci_build_test
+++ b/drake_bazel_download/.github/ci_build_test
@@ -3,5 +3,32 @@
 
 set -euxo pipefail
 
+override_repository=0
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --override-repository)
+      override_repository=1
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
+override_repository_flag=()
+if [[ ${override_repository} -eq 1 ]]; then
+  # Use what we installed to $HOME/drake,
+  # rather than the URL to the most recent nightly release
+  # found in drake_bazel_download/MODULE.bazel.
+  override_repository_flag+=("--override_repository=+_repo_rules2+drake=$HOME/drake")
+
+  # Setup $HOME/drake as a Bazel workspace via
+  # BUILD and WORKSPACE files.
+  ln -sf $(realpath drake.BUILD.bazel) "$HOME/drake/BUILD.bazel"
+  touch "$HOME/drake/WORKSPACE.bazel"
+fi
+
 bazel version
-bazel test //...
+bazel test "${override_repository_flag[@]}" //...

--- a/drake_bazel_download/.github/ci_build_test
+++ b/drake_bazel_download/.github/ci_build_test
@@ -3,12 +3,12 @@
 
 set -euxo pipefail
 
-override_repository=0
+drake_override=0
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --override-repository)
-      override_repository=1
+    --drake-override)
+      drake_override=1
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -17,12 +17,12 @@ while [ "${1:-}" != "" ]; do
   shift
 done
 
-override_repository_flag=()
-if [[ ${override_repository} -eq 1 ]]; then
+drake_override_flag=()
+if [[ ${drake_override} -eq 1 ]]; then
   # Use what we installed to $HOME/drake,
   # rather than the URL to the most recent nightly release
   # found in drake_bazel_download/MODULE.bazel.
-  override_repository_flag+=("--override_repository=+_repo_rules2+drake=$HOME/drake")
+  drake_override_flag+=("--override_repository=+_repo_rules2+drake=$HOME/drake")
 
   # Setup $HOME/drake as a Bazel workspace via
   # BUILD and WORKSPACE files.
@@ -31,4 +31,4 @@ if [[ ${override_repository} -eq 1 ]]; then
 fi
 
 bazel version
-bazel test "${override_repository_flag[@]}" //...
+bazel test "${drake_override_flag[@]}" //...

--- a/drake_bazel_download/.github/ubuntu_setup
+++ b/drake_bazel_download/.github/ubuntu_setup
@@ -3,9 +3,28 @@
 
 set -euxo pipefail
 
+install_args=()
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --experimental-packaging-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --experimental-packaging-url' >&2
+        exit 1
+      fi
+      install_args+=(--experimental-packaging-url $1)
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 echo 'APT::Acquire::Retries "4";' > /etc/apt/apt.conf.d/80-acquire-retries
 echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-setup/install_prereqs
+setup/install_prereqs "${install_args[@]}"

--- a/drake_bazel_download/.github/ubuntu_setup
+++ b/drake_bazel_download/.github/ubuntu_setup
@@ -7,13 +7,13 @@ install_args=()
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --experimental-packaging-url)
+    --package-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --experimental-packaging-url' >&2
+        echo 'No argument specified for --package-url' >&2
         exit 1
       fi
-      install_args+=(--experimental-packaging-url $1)
+      install_args+=(--package-url $1)
       ;;
     *)
       echo 'Invalid command line argument' >&2

--- a/drake_bazel_download/.github/workflows/ci.yml
+++ b/drake_bazel_download/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+    inputs:
+      linux_jammy_experimental_packaging:
+        description: 'Full URL for the Drake linux-jammy-*-experimental-packaging artifact'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz'
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.
@@ -27,7 +32,12 @@ jobs:
         uses: actions/checkout@v4
       - name: setup
         working-directory: drake_bazel_download
-        run: .github/ubuntu_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+          fi
+          .github/ubuntu_setup "${args[@]}"
         shell: bash
       - name: install_bazelisk
         working-directory: drake_bazel_download
@@ -35,5 +45,10 @@ jobs:
         shell: bash
       - name: bazel_download build and test
         working-directory: drake_bazel_download
-        run: .github/ci_build_test
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=(--override-repository)
+          fi
+          .github/ci_build_test "${args[@]}"
         shell: bash

--- a/drake_bazel_download/.github/workflows/ci.yml
+++ b/drake_bazel_download/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/drake_bazel_download/.github/workflows/ci.yml
+++ b/drake_bazel_download/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
-      linux_jammy_experimental_packaging:
-        description: 'Full URL for the Drake linux-jammy-*-experimental-packaging artifact'
+      linux_jammy_package_tar:
+        description: 'Drake linux-jammy-*-packaging .tar.gz artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz'
 concurrency:
@@ -35,7 +35,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
+            args+=(--package-url ${{ github.event.inputs.linux_jammy_package_tar }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash
@@ -48,7 +48,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--override-repository)
+            args+=(--drake-override)
           fi
           .github/ci_build_test "${args[@]}"
         shell: bash

--- a/drake_bazel_download/README.md
+++ b/drake_bazel_download/README.md
@@ -39,3 +39,20 @@ above command prints out; however, be aware that your working directories may
 cause differences. This is important when using tools like
 `drake::FindResource` / `pydrake.common.FindResource`.
 You may generally want to stick to using `bazel run` when able.
+
+### Using a local checkout of Drake
+
+To use an installation of Drake on disk instead of downloaded from github, pass the flag
+``--override_repository=+_repo_rules2+drake=/home/user/stuff/drake`` to bazel on the command line
+or add a line such as the following to ``user.bazelrc`` in the current directory:
+
+```bash
+build --override_repository=+_repo_rules2+drake=/home/user/stuff/drake
+```
+
+Note that the local installation of Drake needs the following two files
+inside its top-level directory:
+
+* an empty `WORKSPACE.bazel` file
+* a symlink or copy of `drake.BUILD.bazel` (found in the current directory
+of this example) named `BUILD.bazel`

--- a/drake_bazel_download/setup/install_prereqs
+++ b/drake_bazel_download/setup/install_prereqs
@@ -31,6 +31,25 @@
 
 set -euxo pipefail
 
+experimental_packaging_url=
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --experimental-packaging-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --experimental-packaging-url' >&2
+        exit 1
+      fi
+      experimental_packaging_url="$1"
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 maybe_sudo=
 if [[ "${EUID}" -ne 0 ]]; then
   maybe_sudo=sudo
@@ -51,8 +70,9 @@ EOF
 )
 
 # Download the drake source
-wget -O drake.tar.gz \
-  https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz
+drake_url="https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz"
+[[ ! -z "${experimental_packaging_url}" ]] && drake_url="${experimental_packaging_url}"
+wget -O drake.tar.gz ${drake_url}
 trap 'rm -f drake.tar.gz' EXIT
 tar -xf drake.tar.gz -C $HOME
 

--- a/drake_bazel_download/setup/install_prereqs
+++ b/drake_bazel_download/setup/install_prereqs
@@ -31,17 +31,17 @@
 
 set -euxo pipefail
 
-experimental_packaging_url=
+package_url=
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --experimental-packaging-url)
+    --package-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --experimental-packaging-url' >&2
+        echo 'No argument specified for --package-url' >&2
         exit 1
       fi
-      experimental_packaging_url="$1"
+      package_url="$1"
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -71,7 +71,7 @@ EOF
 
 # Download the drake source
 drake_url="https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz"
-[[ ! -z "${experimental_packaging_url}" ]] && drake_url="${experimental_packaging_url}"
+[[ ! -z "${package_url}" ]] && drake_url="${package_url}"
 wget -O drake.tar.gz ${drake_url}
 trap 'rm -f drake.tar.gz' EXIT
 tar -xf drake.tar.gz -C $HOME

--- a/drake_cmake_installed/.github/ubuntu_setup
+++ b/drake_cmake_installed/.github/ubuntu_setup
@@ -3,9 +3,28 @@
 
 set -euxo pipefail
 
+install_args=()
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --experimental-packaging-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --experimental-packaging-url' >&2
+        exit 1
+      fi
+      install_args+=(--experimental-packaging-url $1)
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 echo 'APT::Acquire::Retries "4";' > /etc/apt/apt.conf.d/80-acquire-retries
 echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-setup/install_prereqs
+setup/install_prereqs "${install_args[@]}"

--- a/drake_cmake_installed/.github/ubuntu_setup
+++ b/drake_cmake_installed/.github/ubuntu_setup
@@ -7,13 +7,13 @@ install_args=()
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --experimental-packaging-url)
+    --package-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --experimental-packaging-url' >&2
+        echo 'No argument specified for --package-url' >&2
         exit 1
       fi
-      install_args+=(--experimental-packaging-url $1)
+      install_args+=(--package-url $1)
       ;;
     *)
       echo 'Invalid command line argument' >&2

--- a/drake_cmake_installed/.github/workflows/ci.yml
+++ b/drake_cmake_installed/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+    inputs:
+      linux_jammy_experimental_packaging:
+        description: 'Full URL for the Drake linux-jammy-*-experimental-packaging artifact'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz'
+      mac_arm_sonoma_experimental_packaging:
+        description: 'Full URL for the Drake mac-arm-sonoma-*-experimental-packaging artifact'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz'
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.
@@ -37,7 +46,12 @@ jobs:
           sudo rm -rf /Library/Frameworks/Python.framework/
       - name: setup
         working-directory: drake_cmake_installed
-        run: setup/install_prereqs
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }}")
+          fi
+          setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
       - name: cmake_installed build and test
         working-directory: drake_cmake_installed
@@ -52,7 +66,12 @@ jobs:
         uses: actions/checkout@v4
       - name: setup
         working-directory: drake_cmake_installed
-        run: .github/ubuntu_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+          fi
+          .github/ubuntu_setup "${args[@]}"
         shell: bash
       - name: cmake_installed build and test
         working-directory: drake_cmake_installed

--- a/drake_cmake_installed/.github/workflows/ci.yml
+++ b/drake_cmake_installed/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
-      linux_jammy_experimental_packaging:
-        description: 'Full URL for the Drake linux-jammy-*-experimental-packaging artifact'
+      linux_jammy_package_tar:
+        description: 'Drake linux-jammy-*-packaging .tar.gz artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz'
-      mac_arm_sonoma_experimental_packaging:
-        description: 'Full URL for the Drake mac-arm-sonoma-*-experimental-packaging artifact'
+      mac_arm_sonoma_package_tar:
+        description: 'Drake mac-arm-sonoma-*-packaging .tar.gz artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz'
 concurrency:
@@ -49,7 +49,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }})
+            args+=(--package-url ${{ github.event.inputs.mac_arm_sonoma_package_tar }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -69,7 +69,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
+            args+=(--package-url ${{ github.event.inputs.linux_jammy_package_tar }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/drake_cmake_installed/.github/workflows/ci.yml
+++ b/drake_cmake_installed/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }}")
+            args+=(--experimental-packaging-url ${{ github.event.inputs.mac_arm_sonoma_experimental_packaging }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -69,7 +69,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }}")
+            args+=(--experimental-packaging-url ${{ github.event.inputs.linux_jammy_experimental_packaging }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/drake_cmake_installed/setup/install_prereqs
+++ b/drake_cmake_installed/setup/install_prereqs
@@ -4,17 +4,17 @@
 
 set -euxo pipefail
 
-experimental_packaging_url=
+package_url=
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --experimental-packaging-url)
+    --package-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --experimental-packaging-url' >&2
+        echo 'No argument specified for --package-url' >&2
         exit 1
       fi
-      experimental_packaging_url="$1"
+      package_url="$1"
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -35,7 +35,7 @@ case "$OSTYPE" in
 
     # Download the drake source
     drake_url="https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz"
-    [[ ! -z "${experimental_packaging_url}" ]] && drake_url="${experimental_packaging_url}"
+    [[ ! -z "${package_url}" ]] && drake_url="${package_url}"
     curl -o drake.tar.gz ${drake_url}
     trap 'rm -f drake.tar.gz' EXIT
     tar -xf drake.tar.gz -C $HOME
@@ -63,7 +63,7 @@ EOF
 
     # Download the drake source
     drake_url="https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz"
-    [[ ! -z "${experimental_packaging_url}" ]] && drake_url="${experimental_packaging_url}"
+    [[ ! -z "${package_url}" ]] && drake_url="${package_url}"
     wget -O drake.tar.gz ${drake_url}
     trap 'rm -f drake.tar.gz' EXIT
     tar -xf drake.tar.gz -C $HOME

--- a/drake_cmake_installed/setup/install_prereqs
+++ b/drake_cmake_installed/setup/install_prereqs
@@ -4,6 +4,25 @@
 
 set -euxo pipefail
 
+experimental_packaging_url=
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --experimental-packaging-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --experimental-packaging-url' >&2
+        exit 1
+      fi
+      experimental_packaging_url="$1"
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 maybe_sudo=
 
 case "$OSTYPE" in
@@ -15,7 +34,9 @@ case "$OSTYPE" in
     fi
 
     # Download the drake source
-    curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz
+    drake_url="https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz"
+    [[ ! -z "${experimental_packaging_url}" ]] && drake_url="${experimental_packaging_url}"
+    curl -o drake.tar.gz ${drake_url}
     trap 'rm -f drake.tar.gz' EXIT
     tar -xf drake.tar.gz -C $HOME
     ;;
@@ -41,8 +62,9 @@ EOF
     )
 
     # Download the drake source
-    wget -O drake.tar.gz \
-      https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz
+    drake_url="https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz"
+    [[ ! -z "${experimental_packaging_url}" ]] && drake_url="${experimental_packaging_url}"
+    wget -O drake.tar.gz ${drake_url}
     trap 'rm -f drake.tar.gz' EXIT
     tar -xf drake.tar.gz -C $HOME
 

--- a/drake_cmake_installed_apt/.github/ubuntu_apt_setup
+++ b/drake_cmake_installed_apt/.github/ubuntu_apt_setup
@@ -3,19 +3,48 @@
 
 set -euxo pipefail
 
+package_url=
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --package-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --package-url' >&2
+        exit 1
+      fi
+      package_url="$1"
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get -qq update || (sleep 30; apt-get -qq update)
 apt-get -o Acquire::Retries=4 -o Dpkg::Use-Pty=0 -qy --no-install-recommends \
   install build-essential ca-certificates cmake gnupg lsb-release wget
 
-readonly codename="$(lsb_release -cs)"
+if [[ ! -z "${package_url}" ]]; then
+  # Install a custom Drake package if specified.
+  wget -O drake.deb ${package_url}
+  trap 'rm -f drake.deb' EXIT
 
-wget -qO- --retry-connrefused https://drake-apt.csail.mit.edu/drake.asc \
-  | gpg --dearmor - > /etc/apt/trusted.gpg.d/drake.gpg
-echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/${codename} ${codename} main" \
-  > /etc/apt/sources.list.d/drake.list
+  apt-get -o Acquire::Retries=4 -o Dpkg::Use-Pty=0 -qy --no-install-recommends \
+    install ./drake.deb
+else
+  # Otherwise, install the latest released version.
+  readonly codename="$(lsb_release -cs)"
 
-apt-get -qq update || (sleep 30; apt-get -qq update)
-apt-get -o Acquire::Retries=4 -o Dpkg::Use-Pty=0 -qy --no-install-recommends \
-  install drake-dev
+  wget -qO- --retry-connrefused https://drake-apt.csail.mit.edu/drake.asc \
+    | gpg --dearmor - > /etc/apt/trusted.gpg.d/drake.gpg
+  echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/${codename} ${codename} main" \
+    > /etc/apt/sources.list.d/drake.list
+
+  apt-get -qq update || (sleep 30; apt-get -qq update)
+  apt-get -o Acquire::Retries=4 -o Dpkg::Use-Pty=0 -qy --no-install-recommends \
+    install drake-dev
+fi

--- a/drake_cmake_installed_apt/.github/workflows/ci.yml
+++ b/drake_cmake_installed_apt/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+    inputs:
+      linux_jammy_package_deb:
+        description: 'Drake linux-jammy-*-packaging .deb artifact URL'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-jammy.deb'
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.
@@ -27,7 +32,12 @@ jobs:
         uses: actions/checkout@v4
       - name: setup
         working-directory: drake_cmake_installed_apt
-        run: .github/ubuntu_apt_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=(--package-url ${{ github.event.inputs.linux_jammy_package_deb }})
+          fi
+          .github/ubuntu_apt_setup "${args[@]}"
         shell: bash
       - name: cmake_installed_apt build and test
         working-directory: drake_cmake_installed_apt

--- a/drake_pip/.github/ubuntu_setup
+++ b/drake_pip/.github/ubuntu_setup
@@ -3,9 +3,36 @@
 
 set -euxo pipefail
 
+install_args=()
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --wheel-experimental-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --wheel-experimental-url' >&2
+        exit 1
+      fi
+      install_args=(--wheel-experimental-url $1)
+      ;;
+    --python-version)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --python-version' >&2
+        exit 1
+      fi
+      install_args+=(--python-version $1)
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 echo 'APT::Acquire::Retries "4";' > /etc/apt/apt.conf.d/80-acquire-retries
 echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-setup/install_prereqs
+setup/install_prereqs "${install_args[@]}"

--- a/drake_pip/.github/ubuntu_setup
+++ b/drake_pip/.github/ubuntu_setup
@@ -7,13 +7,13 @@ install_args=()
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --wheel-experimental-url)
+    --wheel-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --wheel-experimental-url' >&2
+        echo 'No argument specified for --wheel-url' >&2
         exit 1
       fi
-      install_args=(--wheel-experimental-url $1)
+      install_args=(--wheel-url $1)
       ;;
     --python-version)
       shift

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
-      linux_jammy_wheel_experimental:
-        description: 'Full URL for the Drake linux-jammy-*-wheel-experimental-release artifact (Python 3.10)'
+      linux_jammy_wheel:
+        description: 'Drake linux-jammy-*-wheel-*-release Python 3.10 artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_35_x86_64.whl'
-      mac_arm_sonoma_wheel_experimental:
-        description: 'Full URL for the Drake mac-arm-sonoma-*-wheel-experimental-release artifact (Python 3.12)'
+      mac_arm_sonoma_wheel:
+        description: 'Drake mac-arm-sonoma-*-wheel-*-release Python 3.12 artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp312-cp312-macosx_14_0_arm64.whl'
 concurrency:
@@ -53,7 +53,7 @@ jobs:
         run: |
           args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sonoma_wheel }})
           fi
           setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
@@ -73,7 +73,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.linux_jammy_wheel }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
       - name: venv setup and install
         working-directory: drake_pip
         run: |
-          args=("--python-version '3.12'")
+          args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
           fi
           setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
@@ -73,7 +73,7 @@ jobs:
         run: |
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+    inputs:
+      linux_jammy_wheel_experimental:
+        description: 'Full URL for the Drake linux-jammy-*-wheel-experimental-release artifact (Python 3.10)'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_35_x86_64.whl'
+      mac_arm_sonoma_wheel_experimental:
+        description: 'Full URL for the Drake mac-arm-sonoma-*-wheel-experimental-release artifact (Python 3.12)'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp312-cp312-macosx_14_0_arm64.whl'
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.
@@ -41,7 +50,12 @@ jobs:
           python-version: '3.12'
       - name: venv setup and install
         working-directory: drake_pip
-        run: setup/setup_env 3.12
+        run: |
+          args=("--python-version '3.12'")
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+          fi
+          setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
       - name: pip build and test
         working-directory: drake_pip
@@ -56,7 +70,12 @@ jobs:
         uses: actions/checkout@v4
       - name: pip setup
         working-directory: drake_pip
-        run: .github/ubuntu_setup
+        run: |
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+          fi
+          .github/ubuntu_setup "${args[@]}"
         shell: bash
       - name: pip build and test
         working-directory: drake_pip

--- a/drake_pip/setup/install_prereqs
+++ b/drake_pip/setup/install_prereqs
@@ -7,13 +7,13 @@ setup_env_args=()
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --wheel-experimental-url)
+    --wheel-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --wheel-experimental-url' >&2
+        echo 'No argument specified for --wheel-url' >&2
         exit 1
       fi
-      setup_env_args=(--wheel-experimental-url $1)
+      setup_env_args=(--wheel-url $1)
       ;;
     --python-version)
       shift

--- a/drake_pip/setup/install_prereqs
+++ b/drake_pip/setup/install_prereqs
@@ -3,6 +3,33 @@
 
 set -euxo pipefail
 
+setup_env_args=()
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --wheel-experimental-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --wheel-experimental-url' >&2
+        exit 1
+      fi
+      setup_env_args=(--wheel-experimental-url $1)
+      ;;
+    --python-version)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --python-version' >&2
+        exit 1
+      fi
+      setup_env_args+=(--python-version $1)
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 maybe_sudo=
 if [[ "${EUID}" -ne 0 ]]; then
   maybe_sudo=sudo
@@ -22,4 +49,4 @@ ${maybe_sudo} apt-get install --no-install-recommends $(cat <<EOF
 EOF
 )
 
-setup/setup_env
+setup/setup_env "${setup_env_args[@]}"

--- a/drake_pip/setup/setup_env
+++ b/drake_pip/setup/setup_env
@@ -3,8 +3,40 @@
 
 set -euxo pipefail
 
-PYTHON_VERSION=${1:-'3'}
-echo "Creating virtual environment with python${PYTHON_VERSION}"
+wheel_experimental_url=
+python_version='3'
 
-"python${PYTHON_VERSION}" -m venv env
-"env/bin/pip$PYTHON_VERSION" install -r requirements.txt
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --wheel-experimental-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --wheel-experimental-url' >&2
+        exit 1
+      fi
+      wheel_experimental_url="$1"
+      ;;
+    --python-version)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --python-version' >&2
+        exit 1
+      fi
+      python_version="$1"
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
+echo "Creating virtual environment with python${python_version}"
+"python${python_version}" -m venv env
+# Install from requirements.txt, which currently only includes drake.
+"env/bin/pip$python_version" install -r requirements.txt
+
+# Use experimental wheels if specified, on the respective OS.
+if [[ ! -z "${wheel_experimental_url}" ]]; then
+  "env/bin/pip$python_version" install "${wheel_experimental_url}"
+fi

--- a/drake_pip/setup/setup_env
+++ b/drake_pip/setup/setup_env
@@ -3,18 +3,18 @@
 
 set -euxo pipefail
 
-wheel_experimental_url=
+wheel_url=
 python_version='3'
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --wheel-experimental-url)
+    --wheel-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --wheel-experimental-url' >&2
+        echo 'No argument specified for --wheel-url' >&2
         exit 1
       fi
-      wheel_experimental_url="$1"
+      wheel_url="$1"
       ;;
     --python-version)
       shift
@@ -36,7 +36,7 @@ echo "Creating virtual environment with python${python_version}"
 # Install from requirements.txt, which currently only includes drake.
 "env/bin/pip$python_version" install -r requirements.txt
 
-# Use experimental wheels if specified, on the respective OS.
-if [[ ! -z "${wheel_experimental_url}" ]]; then
-  "env/bin/pip$python_version" install "${wheel_experimental_url}"
+# Use custom wheels if specified, on the respective OS.
+if [[ ! -z "${wheel_url}" ]]; then
+  "env/bin/pip$python_version" install "${wheel_url}"
 fi

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
-      linux_jammy_wheel_experimental:
-        description: 'Full URL for the Drake linux-jammy-*-wheel-experimental-release artifact (Python 3.10)'
+      linux_jammy_wheel:
+        description: 'Drake linux-jammy-*-wheel-*-release Python 3.10 artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_35_x86_64.whl'
-      mac_arm_sonoma_wheel_experimental:
-        description: 'Full URL for the Drake mac-arm-sonoma-*-wheel-experimental-release artifact (Python 3.12)'
+      mac_arm_sonoma_wheel:
+        description: 'Drake mac-arm-sonoma-*-wheel-*-release Python 3.12 artifact URL'
         required: true
         default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp312-cp312-macosx_14_0_arm64.whl'
 concurrency:
@@ -54,7 +54,7 @@ jobs:
           .github/setup
           args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sonoma_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -79,7 +79,7 @@ jobs:
           source $HOME/.profile
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
+            args+=(--wheel-url ${{ github.event.inputs.linux_jammy_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
           .github/ci_build_test

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
         working-directory: drake_poetry
         run: |
           .github/setup
-          args=("--python-version '3.12'")
+          args=(--python-version '3.12')
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -79,7 +79,7 @@ jobs:
           source $HOME/.profile
           args=()
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+            args+=(--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }})
           fi
           setup/install_prereqs "${args[@]}"
           .github/ci_build_test

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+    inputs:
+      linux_jammy_wheel_experimental:
+        description: 'Full URL for the Drake linux-jammy-*-wheel-experimental-release artifact (Python 3.10)'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp310-cp310-manylinux_2_35_x86_64.whl'
+      mac_arm_sonoma_wheel_experimental:
+        description: 'Full URL for the Drake mac-arm-sonoma-*-wheel-experimental-release artifact (Python 3.12)'
+        required: true
+        default: 'https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-cp312-cp312-macosx_14_0_arm64.whl'
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.
@@ -43,7 +52,11 @@ jobs:
         working-directory: drake_poetry
         run: |
           .github/setup
-          setup/install_prereqs 3.12
+          args=("--python-version '3.12'")
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.mac_arm_sonoma_wheel_experimental }}")
+          fi
+          setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
       - name: poetry test
         working-directory: drake_poetry
@@ -64,6 +77,10 @@ jobs:
         run: |
           .github/setup
           source $HOME/.profile
-          setup/install_prereqs
+          args=()
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            args+=("--wheel-experimental-url ${{ github.event.inputs.linux_jammy_wheel_experimental }}")
+          fi
+          setup/install_prereqs "${args[@]}"
           .github/ci_build_test
         shell: bash

--- a/drake_poetry/setup/install_prereqs
+++ b/drake_poetry/setup/install_prereqs
@@ -3,18 +3,18 @@
 
 set -euxo pipefail
 
-wheel_experimental_url=
+wheel_url=
 python_version='3'
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --wheel-experimental-url)
+    --wheel-url)
       shift
       if [[ $# -eq 0 ]]; then
-        echo 'No argument specified for --wheel-experimental-url' >&2
+        echo 'No argument specified for --wheel-url' >&2
         exit 1
       fi
-      wheel_experimental_url="$1"
+      wheel_url="$1"
       ;;
     --python-version)
       shift
@@ -57,10 +57,10 @@ if [[ "$python_version" != "3" ]]; then
   poetry env use $python_version
 fi
 
-# Use experimental wheels if specified, on the respective OS.
+# Use custom wheels if specified, on the respective OS.
 # Note that this will modify the pyproject.toml and the poetry.lock files.
-if [[ ! -z "${wheel_experimental_url}" ]]; then
-  poetry add "${wheel_experimental_url}"
+if [[ ! -z "${wheel_url}" ]]; then
+  poetry add "${wheel_url}"
 fi
 
 # Install poetry dependencies.

--- a/drake_poetry/setup/install_prereqs
+++ b/drake_poetry/setup/install_prereqs
@@ -3,6 +3,34 @@
 
 set -euxo pipefail
 
+wheel_experimental_url=
+python_version='3'
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --wheel-experimental-url)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --wheel-experimental-url' >&2
+        exit 1
+      fi
+      wheel_experimental_url="$1"
+      ;;
+    --python-version)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --python-version' >&2
+        exit 1
+      fi
+      python_version="$1"
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
 maybe_sudo=
 if [[ "${EUID}" -ne 0 ]]; then
   maybe_sudo=sudo
@@ -24,11 +52,16 @@ fi
 
 # If a version of Python other than the default (3) is provided,
 # enforce that poetry use that version.
-PYTHON_VERSION=${1:-'3'}
-echo "Creating poetry environment with python${PYTHON_VERSION}"
-if [[ "$PYTHON_VERSION" != "3" ]]; then
-  poetry env use $PYTHON_VERSION
+echo "Creating poetry environment with python${python_version}"
+if [[ "$python_version" != "3" ]]; then
+  poetry env use $python_version
 fi
 
-# Install poetry dependencies
+# Use experimental wheels if specified, on the respective OS.
+# Note that this will modify the pyproject.toml and the poetry.lock files.
+if [[ ! -z "${wheel_experimental_url}" ]]; then
+  poetry add "${wheel_experimental_url}"
+fi
+
+# Install poetry dependencies.
 poetry install

--- a/private/test/file_sync_test.py
+++ b/private/test/file_sync_test.py
@@ -5,6 +5,7 @@
 each other are actually so.
 """
 
+from itertools import chain
 import logging
 import os
 import re
@@ -22,7 +23,6 @@ COPIES = (
     (
         "drake_bazel_download/.github/ubuntu_setup",
         "drake_cmake_installed/.github/ubuntu_setup",
-        "drake_pip/.github/ubuntu_setup",
     ),
     (
         "drake_bazel_download/CPPLINT.cfg",
@@ -41,10 +41,15 @@ COPIES = (
         "drake_pip/LICENSE",
         "drake_poetry/LICENSE",
     ),
-    (
-        "drake_bazel_download/.github/ci_build_test",
-        "drake_bazel_external/.github/ci_build_test",
-    ),
+    # TODO(tyankee): These aren't synced right now because
+    # drake_bazel_download runs in GHA while drake_bazel_external
+    # runs in Jenkins, and only GHA has been updated so far.
+    # Perhaps this can be brought back once the Jenkins changes
+    # are introduced.
+    # (
+    #     "drake_bazel_download/.github/ci_build_test",
+    #     "drake_bazel_external/.github/ci_build_test",
+    # ),
     (
         "drake_bazel_external/.github/ubuntu_setup",
         "drake_cmake_external/.github/ubuntu_setup",
@@ -114,6 +119,27 @@ GITHUB_WORKFLOWS = (
     "poetry"
 )
 
+GITHUB_WORKFLOW_OPTS = {
+    "bazel_download": (
+        "linux_jammy_package_tar",
+    ),
+    "cmake_installed": (
+        "linux_jammy_package_tar",
+        "mac_arm_sonoma_package_tar"
+    ),
+    "cmake_installed_apt": (
+        "linux_jammy_package_deb",
+    ),
+    **dict.fromkeys([
+        "pip",
+        "poetry"
+    ],
+    (
+        "linux_jammy_wheel",
+        "mac_arm_sonoma_wheel"
+    ))
+}
+
 found_errors = False
 
 
@@ -157,34 +183,100 @@ def check(index: int, paths: tuple[str]):
     if not all_match:
         error(f"{prologue} do not all match")
 
-
 def gha_workflow_check(workflow_name: str):
-    """Enforces the subdir_ci to have the contents of root_ci up until
-    it reaches the jobs: line plus the content in the subdir_ workflow
-    after jobs: is mentioned.
+    """Enforces the following contents of root_ci and subdir_ci:
+        1. subdir_ci and root_ci match until 'workflow_dispatch:'
+        2. root_ci and subdir_ workflow match from 'workflow_dispatch:' until 'concurrency:',
+           for only the options corresponding to the given workflow
+        3. subdir_ci and root_ci match from 'concurrency:' until 'jobs:'
+        4. subdir_ci and subdir_ workflow match after 'jobs:'
     """
     root_ci_path = ".github/workflows/ci.yml"
     subdir_workflow_path = f".github/workflows/{workflow_name}.yml"
     subdir_ci_path = f"drake_{workflow_name}/.github/workflows/ci.yml"
-    sep = "\njobs:\n"
+    paths = [ root_ci_path, subdir_workflow_path, subdir_ci_path ]
+    seps = [
+        "\n  workflow_dispatch:\n    inputs:\n",
+        "\nconcurrency:\n",
+        "\njobs:\n"
+    ]
 
-    # Read all files into memory and check sep occurs once in each file.
+    # Read all files into memory.
     content = {}
-    for path in [root_ci_path, subdir_workflow_path, subdir_ci_path]:
+    for path in paths:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 content[path] = f.read()
-                if len(re.findall(sep, content[path])) != 1:
-                    error(f"{workflow_name}'s {path} contents are invalid")
         except IOError:
             error(f"Missing {workflow_name} file {path}")
+            exit(1)
 
-    # Workflow check.
-    events = content[root_ci_path].split(sep)[0]
-    ex_jobs = sep + content[subdir_workflow_path].split(sep)[1]
+    # Check that seps occur once in each file.
+    def check_sep(paths, sep):
+        for path in paths:
+            if len(re.findall(sep, content[path])) != 1:
+                error(f"{workflow_name}'s {path} contents are invalid: does not include {sep}")
+                exit(1)
+    check_sep([root_ci_path, subdir_ci_path], seps[0])
+    check_sep([root_ci_path, subdir_ci_path], seps[1])
+    check_sep(paths, seps[2])
 
-    if events + ex_jobs != content[subdir_ci_path]:
-        error(f"{workflow_name} subdir CI does not match")
+    # Workflow check. See above for steps.
+    root_events = content[root_ci_path].split(seps[0])[0]
+    subdir_events = content[subdir_ci_path].split(seps[0])[0]
+    if root_events != subdir_events:
+        error(f"{workflow_name} subdir CI events do not match")
+
+    # Custom logic for workflow dispatch based on options defined above.
+    root_dispatch = (content[root_ci_path].split(seps[0]))[1].split(seps[1])[0].splitlines()
+    subdir_dispatch = (content[subdir_ci_path].split(seps[0]))[1].split(seps[1])[0].splitlines()
+    def get_option_definition(dispatch, option_line):
+        dispatch_option = [option_line]
+        l = dispatch.index(option_line) + 1
+        while l < len(dispatch):
+            if len(dispatch[l]) - len(dispatch[l].lstrip()) == 8:
+                dispatch_option.append(dispatch[l])
+                l += 1
+            else:
+                break
+        return dispatch_option
+
+    for dispatch_option in GITHUB_WORKFLOW_OPTS[workflow_name]:
+        dispatch_option_line = f"      {dispatch_option}:"
+
+        # Check that all options occur in both files.
+        if (dispatch_option_line not in root_dispatch or
+            dispatch_option_line not in subdir_dispatch):
+            error(f"{workflow_name} subdir workflow_dispatch does not match: missing {dispatch_option}")
+            exit(1)
+
+        # Find the next line which is not indented to the sub-level,
+        # representing the next option (or end).
+        root_dispatch_option = get_option_definition(root_dispatch, dispatch_option_line)
+        subdir_dispatch_option = get_option_definition(subdir_dispatch, dispatch_option_line)
+        if root_dispatch_option != subdir_dispatch_option:
+            error(f"{workflow_name} subdir CI workflow_dispatch option {dispatch_option} does not match")
+
+    # Check that the subdir and root workflows define no extra options
+    # beyond what is configured here.
+    subdir_dispatch_options = sum([1 for line in subdir_dispatch if len(line) - len(line.lstrip()) == 6])
+    if subdir_dispatch_options != len(GITHUB_WORKFLOW_OPTS[workflow_name]):
+        error(f"{workflow_name} subdir CI defines additional options than expected. Please add them to the file_sync_test.")
+    all_dispatch_options = set(chain(*GITHUB_WORKFLOW_OPTS.values()))
+    root_dispatch_options = sum([1 for line in root_dispatch if len(line) - len(line.lstrip()) == 6])
+    if root_dispatch_options != len(all_dispatch_options):
+        error(f"Root CI workflow_dispatch defines additional options than expected. Please add them to the file_sync_test.")
+    # End workflow dispatch custom logic.
+
+    root_conc = (content[root_ci_path].split(seps[1]))[1].split(seps[2])[0]
+    subdir_conc = (content[subdir_ci_path].split(seps[1]))[1].split(seps[2])[0]
+    if root_conc != subdir_conc:
+        error(f"{workflow_name} subdir CI concurrency does not match")
+
+    subdir_jobs = content[subdir_ci_path].split(seps[2])[1]
+    subdir_workflow_jobs = content[subdir_workflow_path].split(seps[2])[1]
+    if subdir_jobs != subdir_workflow_jobs:
+        error(f"{workflow_name} subdir CI jobs do not match")
 
 
 def main():


### PR DESCRIPTION
This introduces parameters on each of the GitHub Actions examples to be able to run the CI jobs with alternative versions of Drake. Towards [#22574](https://github.com/RobotLocomotion/drake/issues/22574).

Changes to each example are as follows:

* `drake_cmake_installed`: install an experimental package of Drake into `$HOME/drake`, and use that when `cmake -DCMAKE_PREFIX_PATH=<path> ..` is called to configure/generate
* `drake_cmake_installed_apt`: uses `apt-get install <url>` with a link to an experimental package
* `drake_bazel_download`: similar to `drake_cmake_installed`, but uses Bazel's `--override-repository` flag when calling `bazel test //...`
* `drake_pip`: uses `pip install <url>` with a link to experimental wheels (*note*: does this after installing drake from `requirements.txt`, in case any other packages are added to that file in the future)
* `drake_poetry`: similar to `drake_pip`, but uses `poetry add <url>`

Additionally, modifies the CI config files to add parameters to the `workflow_dispatch` event. 

* `linux_jammy_package_tar`
* `linux_jammy_package_deb`
* `mac_arm_sonoma_package_tar`
* `linux_jammy_wheel`
* `mac_arm_sonoma_wheel`

The use case here is that a developer with a PR on Drake could test their changes on DEE with the following workflow:

* Run experimental packaging builds on Linux Jammy and macOS Sonoma and obtain the artifact URLs.
* Run experimental wheel builds on Linux Jammy and macOS Sonoma and obtain the artifact URLs.
* Navigate to DEE's Actions page and kick off a build of all GHA examples, inputting the URLs from above.

Tested via GHA on my forked repo (TODO will insert link here).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/371)
<!-- Reviewable:end -->
