### PR TITLE
Add workflow_dispatch event to main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - main
   schedule:
     - cron: '0 12 * * *'
+  workflow_dispatch:
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.

--- a/drake_bazel_download/.github/workflows/ci.yml
+++ b/drake_bazel_download/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - main
   schedule:
     - cron: '0 12 * * *'
+  workflow_dispatch:
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.

--- a/drake_cmake_installed/.github/workflows/ci.yml
+++ b/drake_cmake_installed/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - main
   schedule:
     - cron: '0 12 * * *'
+  workflow_dispatch:
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.

--- a/drake_cmake_installed_apt/.github/workflows/ci.yml
+++ b/drake_cmake_installed_apt/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - main
   schedule:
     - cron: '0 12 * * *'
+  workflow_dispatch:
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - main
   schedule:
     - cron: '0 12 * * *'
+  workflow_dispatch:
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - main
   schedule:
     - cron: '0 12 * * *'
+  workflow_dispatch:
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
   # This will not cancel CI runs associated with `schedule` or `push`.


### PR DESCRIPTION
Needed for #371 as part of the effort towards [#22574](https://github.com/RobotLocomotion/drake/issues/22574). Allows manual builds on all of the CI jobs ... there will be parameters to these jobs in the future, but for testing, at minimum this needs to be enabled on main.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/373)
<!-- Reviewable:end -->
