### PR TITLE
Added support for poetry 2.0.0 (#378)

### DIFF
--- a/drake_poetry/pyproject.toml
+++ b/drake_poetry/pyproject.toml
@@ -2,14 +2,14 @@
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[project]
+name = "drake-external-examples"
+version = "0.1.0"
+description = "External examples for Drake"
+authors = [{ name = "RobotLocomotion" }]
+readme = "README.md"
+requires-python = ">=3.10, <4.0"
+dependencies = ["drake~=1.39.0"]
+
 [tool.poetry]
 package-mode = false
-description = "Example poetry project using Drake"
-authors = ["RobotLocomotion <@>"]
-readme = "README.md"
-
-# Currently, this only includes a recent version of Drake.
-# Feel free to add more packages for your own project below!
-[tool.poetry.dependencies]
-python = "^3.10"
-drake = "^1.39.0"

--- a/drake_poetry/setup/install_prereqs
+++ b/drake_poetry/setup/install_prereqs
@@ -22,13 +22,29 @@ EOF
     )
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS-specific logic
+    # enforce use of Python 3.12 if available, otherwise fall back to 3.11
+    if brew list python@3.11 &>/dev/null || brew list python@3.12 &>/dev/null; then
+        if brew list python@3.12 &>/dev/null; then
+            PYTHON_VERSION=${1:-'3.12'}
+        else
+            PYTHON_VERSION=${1:-'3.11'}
+        fi
+    else
+        echo "ERROR: Compatible Python interpreter not found!"
+        echo "Please install Python 3.12 via Homebrew: brew install python@3.12"
+        exit 1
+    fi
+else
+    # Default for non-macOS platforms
+    PYTHON_VERSION=${1:-'3'}
+fi
+
 # If a version of Python other than the default (3) is provided,
 # enforce that poetry use that version.
-PYTHON_VERSION=${1:-'3'}
 echo "Creating poetry environment with python${PYTHON_VERSION}"
-if [[ "$PYTHON_VERSION" != "3" ]]; then
-  poetry env use $PYTHON_VERSION
-fi
+poetry env use $PYTHON_VERSION
 
 # Install poetry dependencies
 poetry install


### PR DESCRIPTION
Addresses #378 

Updated the `drake_poetry` example to work with `poetry>=2.0.0`. Changes include
- Reformatting `pyproject.toml` to be compatible with PEP 621 and the most recent poetry upgrade. This simultaneously addresses a dependabot issue involving automated version bumping for drake.
- Enforcing python interpreter constraints on macOS. Prior to this change, the `setup/install_prereqs` script for this example would break on Mac systems with python 3.13 installed, as drake does not yet officially support this release on macOS. The additional logic ensures that poetry is run using an officially supported python version. 