### PR TITLE
[CMake Examples] Update required CMake versions

### DIFF
--- a/drake_cmake_external/CMakeLists.txt
+++ b/drake_cmake_external/CMakeLists.txt
@@ -3,8 +3,25 @@
 # TODO(eric.cousineau): Link to documentation on superproject example pending
 # resolution of: https://gitlab.kitware.com/cmake/cmake/issues/18336
 
-cmake_minimum_required(VERSION 3.16)
+# See https://drake.mit.edu/from_source.html for the versions of CMake
+# officially supported by Drake.
+cmake_minimum_required(VERSION 3.22)
 project(drake_cmake_external)
+
+# Enable ExternalProject_Add to set the timestamp of all extracted contents
+# to the time of extraction, ensuring anything that depends on the extracted
+# contents will be rebuilt whenever the URL changes.
+# This behavior is preferred by CMake >= 3.24, and is controlled by the
+# DOWNLOAD_EXTRACT_TIMESTAMP option introduced in that version of CMake.
+# See https://cmake.org/cmake/help/latest/policy/CMP0135.html
+# for details on this policy and
+# https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#transition-schedule
+# for details on transitioning policies between versions of CMake.
+# TODO(tyler.yankee): Remove this when Drake no longer officially supports
+# versions of CMake older than 3.24.
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING

--- a/drake_cmake_external/CMakeLists.txt
+++ b/drake_cmake_external/CMakeLists.txt
@@ -4,24 +4,9 @@
 # resolution of: https://gitlab.kitware.com/cmake/cmake/issues/18336
 
 # See https://drake.mit.edu/from_source.html for the versions of CMake
-# officially supported by Drake.
-cmake_minimum_required(VERSION 3.22)
+# officially supported by Drake when building from source.
+cmake_minimum_required(VERSION 3.22...4.0)
 project(drake_cmake_external)
-
-# Enable ExternalProject_Add to set the timestamp of all extracted contents
-# to the time of extraction, ensuring anything that depends on the extracted
-# contents will be rebuilt whenever the URL changes.
-# This behavior is preferred by CMake >= 3.24, and is controlled by the
-# DOWNLOAD_EXTRACT_TIMESTAMP option introduced in that version of CMake.
-# See https://cmake.org/cmake/help/latest/policy/CMP0135.html
-# for details on this policy and
-# https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#transition-schedule
-# for details on transitioning policies between versions of CMake.
-# TODO(tyler.yankee): Remove this when Drake no longer officially supports
-# versions of CMake older than 3.24.
-if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 NEW)
-endif()
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING

--- a/drake_cmake_installed/CMakeLists.txt
+++ b/drake_cmake_installed/CMakeLists.txt
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MIT-0
 
-# See https://drake.mit.edu/from_source.html for the versions of CMake
-# officially supported by Drake.
-cmake_minimum_required(VERSION 3.22)
+# Note that the minimum required version of CMake to consume a binary
+# installation of Drake is lower than the minimum required version
+# when building Drake from source (as seen in drake_cmake_external).
+# The maximum version below allows for the use of modern policies
+# with newer versions of CMake.
+cmake_minimum_required(VERSION 3.9...4.0)
 project(drake_cmake_installed)
 
 # N.B. This is a temporary flag. It only really applies to Linux, as Mac

--- a/drake_cmake_installed/CMakeLists.txt
+++ b/drake_cmake_installed/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT-0
 
-cmake_minimum_required(VERSION 3.16)
+# See https://drake.mit.edu/from_source.html for the versions of CMake
+# officially supported by Drake.
+cmake_minimum_required(VERSION 3.22)
 project(drake_cmake_installed)
 
 # N.B. This is a temporary flag. It only really applies to Linux, as Mac

--- a/drake_cmake_installed_apt/CMakeLists.txt
+++ b/drake_cmake_installed_apt/CMakeLists.txt
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MIT-0
 
-# See https://drake.mit.edu/from_source.html for the versions of CMake
-# officially supported by Drake.
-cmake_minimum_required(VERSION 3.22)
+# Note that the minimum required version of CMake to consume a binary
+# installation of Drake is lower than the minimum required version
+# when building Drake from source (as seen in drake_cmake_external).
+# The maximum version below allows for the use of modern policies
+# with newer versions of CMake.
+cmake_minimum_required(VERSION 3.9...4.0)
 project(drake_cmake_installed_apt)
 
 include(CTest)

--- a/drake_cmake_installed_apt/CMakeLists.txt
+++ b/drake_cmake_installed_apt/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT-0
 
-cmake_minimum_required(VERSION 3.16)
+# See https://drake.mit.edu/from_source.html for the versions of CMake
+# officially supported by Drake.
+cmake_minimum_required(VERSION 3.22)
 project(drake_cmake_installed_apt)
 
 include(CTest)


### PR DESCRIPTION
Closes [#22889](https://github.com/RobotLocomotion/drake/issues/22889).

* Updates `drake_cmake_external` to use CMake 3.22...4.0 in accordance with https://drake.mit.edu/from_source.html (as of writing) while allowing for modern policies.
* Updates `drake_cmake_installed` and `drake_cmake_installed_apt` to use CMake 3.9...4.0, as consuming binary Drake does not *require* modern CMake, but we'll allow modern policies (and get rid of deprecation warnings about older versions when using newer ones).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/384)
<!-- Reviewable:end -->
