### PR TITLE
[drake_cmake_installed] Remove no-op temporary CMake option

### DIFF
--- a/drake_cmake_installed/CMakeLists.txt
+++ b/drake_cmake_installed/CMakeLists.txt
@@ -3,10 +3,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(drake_cmake_installed)
 
-# N.B. This is a temporary flag. It only really applies to Linux, as Mac
-# does not need X11.
-option(RUN_X11_TESTS "Run tests that require X11" OFF)
-
 include(CTest)
 
 find_package(drake CONFIG REQUIRED)


### PR DESCRIPTION
As far as I can tell, this option isn't being used anywhere here or in Drake itself, and was last updated several years ago.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/386)
<!-- Reviewable:end -->
