### PR TITLE
[drake_bazel_download] Drop lcm_coretypes from includes

### DIFF
--- a/drake_bazel_download/drake.BUILD.bazel
+++ b/drake_bazel_download/drake.BUILD.bazel
@@ -35,16 +35,9 @@ _THIRD_SHLIBS = glob([
 ], allow_empty = True)
 
 cc_library(
-    name = "_lcm_coretypes",
-    hdrs = ["include/lcm/lcm/lcm_coretypes.h"],
-    strip_include_prefix = "include/lcm",
-)
-
-cc_library(
     name = "_drake_headers",
     hdrs = glob(["include/drake/**"]),
     strip_include_prefix = "include",
-    deps = [":_lcm_coretypes"],
 )
 
 [


### PR DESCRIPTION
This has been unnecessary since RobotLocomotion/drake#20761, and now with RobotLocomotion/drake#22939 has become an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/390)
<!-- Reviewable:end -->
