### PR TITLE
[drake_cmake_external] CI: Apply narrower `apt autoremove`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def jobs = [:]
 for (example in examples) {
   def name = example
   jobs[name] = {
-    node('linux-jammy-unprovisioned') {
+    node('linux-noble-unprovisioned') {
       timeout(600) {
         ansiColor('xterm') {
           try {

--- a/drake_bazel_external/.github/ubuntu_setup
+++ b/drake_bazel_external/.github/ubuntu_setup
@@ -16,7 +16,7 @@ export DEBIAN_FRONTEND='noninteractive'
 apt-get update
 apt-get install --no-install-recommends lsb-release
 
-if [[ "$(lsb_release -sc)" != 'jammy' ]]; then
-  echo 'This script requires Ubuntu 22.04 (Jammy)' >&2
+if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+  echo 'This script requires Ubuntu 24.04 (Noble)' >&2
   exit 3
 fi

--- a/drake_bazel_external_legacy/.github/ubuntu_setup
+++ b/drake_bazel_external_legacy/.github/ubuntu_setup
@@ -16,7 +16,7 @@ export DEBIAN_FRONTEND='noninteractive'
 apt-get update
 apt-get install --no-install-recommends lsb-release
 
-if [[ "$(lsb_release -sc)" != 'jammy' ]]; then
-  echo 'This script requires Ubuntu 22.04 (Jammy)' >&2
+if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+  echo 'This script requires Ubuntu 24.04 (Noble)' >&2
   exit 3
 fi

--- a/drake_cmake_external/.github/setup
+++ b/drake_cmake_external/.github/setup
@@ -9,8 +9,12 @@ sudo .github/ubuntu_setup
 # drake source setup
 setup/install_prereqs "$@"
 
+# Prevent removal for AWS-related packages on Noble.
+if [[ "$(lsb_release -sc)" == 'noble' ]]; then
+    sudo apt-mark hold \
+        linux-aws linux-headers-aws linux-image-aws linux-tools-aws
+fi
 # Provide regression coverage for the WITH_USER_...=ON options by un-installing
 # packages that should not be necessary in this particular build flavor. This
 # example configures them to be built from source.
-sudo apt-get remove libeigen3-dev libfmt-dev libspdlog-dev
-sudo apt-get autoremove
+sudo apt-get purge --autoremove libeigen3-dev libfmt-dev libspdlog-dev

--- a/drake_cmake_external/.github/ubuntu_setup
+++ b/drake_cmake_external/.github/ubuntu_setup
@@ -16,7 +16,7 @@ export DEBIAN_FRONTEND='noninteractive'
 apt-get update
 apt-get install --no-install-recommends lsb-release
 
-if [[ "$(lsb_release -sc)" != 'jammy' ]]; then
-  echo 'This script requires Ubuntu 22.04 (Jammy)' >&2
+if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+  echo 'This script requires Ubuntu 24.04 (Noble)' >&2
   exit 3
 fi


### PR DESCRIPTION
Unblocks #397. On Noble, this is causing `linux-aws-*` packages to be removed, which breaks CI.

This code is only meant to provide regression coverage for the specified packages, and should not be applying `autoremove` globally on the system to remove any other extraneous packages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/399)
<!-- Reviewable:end -->
