### PR TITLE
[drake_bazel_external] Add .bazelrc flag for compiler version

### DIFF
--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -22,6 +22,14 @@ build --action_env=CCACHE_DISABLE=1
 # https://github.com/RobotLocomotion/drake/blob/master/tools/flags/BUILD.bazel
 build --@drake//tools/flags:public_repo_default=pkgconfig
 
+# Pass along the compiler major version to Drake. This doesn't actually set or
+# change the compiler used for the build, but tells Drake's CC rules what
+# version to expect to tweak compiler- and version-specific flags accordingly.
+# In particular, many warnings are suppressed when using gcc-13 (the default
+# on Ubuntu 24.04 Noble). Adapt this flag to your system's compiler major
+# version as necessary.
+# build --@drake//tools/cc_toolchain:compiler_major=13
+
 # For Ubuntu builds, this flag can cut build times in half. For macOS builds,
 # this flag might cause build errors. We suggest turning it on if and only if
 # your project doesn't use macOS.

--- a/drake_bazel_external/.github/ci_build_test
+++ b/drake_bazel_external/.github/ci_build_test
@@ -3,10 +3,20 @@
 
 set -euxo pipefail
 
+cat <<EOF > "user.bazelrc"
 # Use what we downloaded to drake_bazel_external/drake,
 # rather than the URL to the latest Drake master branch
 # found in drake_bazel_external/MODULE.bazel.
-override_module_flag="--override_module=drake=drake"
+build --override_module=drake=drake
+
+# Pass along the compiler version to Drake
+# (as suggested in drake_bazel_external/.bazelrc).
+build --@drake//tools/cc_toolchain:compiler_major=$(gcc -dumpversion)
+
+# Use force_pic to speed up the build, as this only runs on Ubuntu
+# (as suggested in drake_bazel_external/.bazelrc).
+build --force_pic=yes
+EOF
 
 bazel version
-bazel test "${override_module_flag}" //...
+bazel test //...

--- a/drake_bazel_external_legacy/.bazelrc
+++ b/drake_bazel_external_legacy/.bazelrc
@@ -21,6 +21,14 @@ build --host_cxxopt=-std=c++20
 # https://github.com/bazelbuild/bazel/issues/1164
 build --action_env=CCACHE_DISABLE=1
 
+# Pass along the compiler major version to Drake. This doesn't actually set or
+# change the compiler used for the build, but tells Drake's CC rules what
+# version to expect to tweak compiler- and version-specific flags accordingly.
+# In particular, many warnings are suppressed when using gcc-13 (the default
+# on Ubuntu 24.04 Noble). Adapt this flag to your system's compiler major
+# version as necessary.
+# build --@drake//tools/cc_toolchain:compiler_major=13
+
 # For Ubuntu builds, this flag can cut build times in half. For macOS builds,
 # this flag might cause build errors. We suggest turning it on if and only if
 # your project doesn't use macOS.

--- a/drake_bazel_external_legacy/.github/ci_build_test
+++ b/drake_bazel_external_legacy/.github/ci_build_test
@@ -3,6 +3,16 @@
 
 set -euxo pipefail
 
+cat <<EOF > "user.bazelrc"
+# Pass along the compiler version to Drake
+# (as suggested in drake_bazel_external/.bazelrc).
+build --@drake//tools/cc_toolchain:compiler_major=$(gcc -dumpversion)
+
+# Use force_pic to speed up the build, as this only runs on Ubuntu
+# (as suggested in drake_bazel_external/.bazelrc).
+build --force_pic=yes
+EOF
+
 # Use what we downloaded to drake_bazel_external_legacy/drake,
 # rather than the URL to the latest Drake master branch
 # found in drake_bazel_external_legacy/WORKSPACE.


### PR DESCRIPTION
Towards #400.

Pass the compiler major version to Drake to enable some compiler warning suppression for gcc-13. (Drake's build applies this flag, but Drake consumers must apply it for their own builds.)

Also cleanup CI by writing a `%workspace%/user.bazelrc` file with the appropriate flags that are commented out in the example `.bazelrc` (including `--force_pic`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/401)
<!-- Reviewable:end -->
