### PR TITLE
Add range strategy field to renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,10 @@
       "matchFiles": ["drake_poetry/pyproject.toml"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "poetry-deps"
+    },
+    {
+      "matchPackageNames": ["drake"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
Towards #393 

Explicitly specify version bump strategy. Turns out renovate was successfully finding drake `1.42`, it just didn't know what to do with it. This change should bump the version as expected per the schedule defined in renovate.json.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/404)
<!-- Reviewable:end -->
