### PR TITLE
Automate `.bazelversion` and `MODULE.bazel` upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,46 +10,29 @@
   "timezone": "America/New_York",
   "enabledManagers": [
     "pip_requirements",
-    "poetry"
+    "poetry",
+    "bazelisk",
+    "bazel-module"
   ],
   "includePaths": [
     "drake_pip/**",
-    "drake_poetry/**"
+    "drake_poetry/**",
+    "drake_bazel_download/**",
+    "drake_bazel_external/**"
   ],
-  "pip_requirements": {
-    "managerFilePatterns": [
-      "/drake_pip/requirements\\.txt$/"
-    ]
-  },
-  "poetry": {
-    "managerFilePatterns": [
-      "/drake_poetry/pyproject\\.toml$/"
-    ]
-  },
   "packageRules": [
     {
-      "matchManagers": [
-        "pip_requirements"
-      ],
-      "matchFileNames": [
-        "drake_pip/requirements.txt"
-      ],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "pip-deps"
-    },
-    {
-      "matchManagers": [
-        "poetry"
-      ],
-      "matchFileNames": [
-        "drake_poetry/pyproject.toml"
-      ],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "poetry-deps"
-    },
-    {
       "matchPackageNames": [
-        "drake"
+        "apple_support"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "pip_requirements",
+        "poetry",
+        "bazelisk",
+        "bazel-module"
       ],
       "rangeStrategy": "bump"
     }


### PR DESCRIPTION
Closes #407 

Update Renovate configuration file to manage the .bazelversion and MODULE.bazel version bumps in the `drake_bazel_download` and `drake_bazel_external` examples. Additionally, these changes remove excess/redundant configuration options from renovate.json that have no effect on functionality.