### PR TITLE
[drake_cmake_external] Remove explicit gcc in CI

### DIFF
--- a/drake_cmake_external/.github/ci_build_test
+++ b/drake_cmake_external/.github/ci_build_test
@@ -36,12 +36,6 @@ if [[ ! -z "${drake_commit_hash}" ]]; then
   cmake_args+=(-DDRAKE_COMMIT_HASH=${drake_commit_hash})
 fi
 
-# TODO(drake#23119): Explicitly use /usr/bin/gcc and /usr/bin/g++, because
-# Drake's warning suppressions don't correctly identify /usr/bin/{cc|c++}
-# as the underlying compilers.
-cmake_args+=(-DCMAKE_C_COMPILER=/usr/bin/gcc)
-cmake_args+=(-DCMAKE_CXX_COMPILER=/usr/bin/g++)
-
 cmake .. "${cmake_args[@]}"
 cmake --build .
 


### PR DESCRIPTION
Amend 2d854ee since Drake has been fixed upstream (RobotLocomotion/drake#23117).

Closes #400.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/415)
<!-- Reviewable:end -->
