### PR TITLE
[Bazel examples] Use prefer_pic_for_opt_binaries

### DIFF
--- a/drake_bazel_download/.bazelrc
+++ b/drake_bazel_download/.bazelrc
@@ -2,6 +2,7 @@
 
 # Default to an optimized build.
 build --compilation_mode=opt
+build --features=prefer_pic_for_opt_binaries
 
 # Default build options.
 build --strip=never
@@ -16,11 +17,6 @@ build --host_cxxopt=-std=c++20
 
 # https://github.com/bazelbuild/bazel/issues/1164
 build --action_env=CCACHE_DISABLE=1
-
-# For Ubuntu builds, this flag can cut build times in half. For macOS builds,
-# this flag might cause build errors. We suggest turning it on if and only if
-# your project doesn't use macOS.
-## build --force_pic=yes
 
 # TODO(jwnimmer-tri) We should see if we can reuse more of Drake's
 # customizations somehow.

--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -2,6 +2,7 @@
 
 # Default to an optimized build.
 build --compilation_mode=opt
+build --features=prefer_pic_for_opt_binaries
 
 # Default build options.
 build --strip=never
@@ -29,11 +30,6 @@ build --@drake//tools/flags:public_repo_default=pkgconfig
 # on Ubuntu 24.04 Noble). Adapt this flag to your system's compiler major
 # version as necessary.
 # build --@drake//tools/cc_toolchain:compiler_major=13
-
-# For Ubuntu builds, this flag can cut build times in half. For macOS builds,
-# this flag might cause build errors. We suggest turning it on if and only if
-# your project doesn't use macOS.
-## build --force_pic=yes
 
 # Drake supports the use of proprietary solvers for mathematical programs.
 # See https://drake.mit.edu/bazel.html#proprietary-solvers for more info

--- a/drake_bazel_external/.github/ci_build_test
+++ b/drake_bazel_external/.github/ci_build_test
@@ -12,10 +12,6 @@ build --override_module=drake=drake
 # Pass along the compiler version to Drake
 # (as suggested in drake_bazel_external/.bazelrc).
 build --@drake//tools/cc_toolchain:compiler_major=$(gcc -dumpversion)
-
-# Use force_pic to speed up the build, as this only runs on Ubuntu
-# (as suggested in drake_bazel_external/.bazelrc).
-build --force_pic=yes
 EOF
 
 bazel version


### PR DESCRIPTION
Drake upstream has switched to using prefer_pic_for_opt_binaries, which supplants --force_pic (and avoids the platform-specific logic of when to use it). Downstream users must also apply it to their own builds.

Closes RobotLocomotion/drake#20336.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/417)
<!-- Reviewable:end -->
