### PR TITLE
Use nightly trigger for main branch always

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ props << parameters([
       'Defaults to <code>master</code>.'),
 ])
 
-if (env.BRANCH_NAME == 'main' && !is_downstream_build) {
+if (env.BRANCH_NAME == 'main') {
   def triggers = []
   triggers << cron('H H(7-8) * * *')
   props << pipelineTriggers(triggers)


### PR DESCRIPTION
Whether the build is a downstream experimental drake job should not affect the nightly triggering (though it still should disable the emails on failure).

Closes #429.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/430)
<!-- Reviewable:end -->
