### PR TITLE
[drake_bazel_download] Modernize spelling for host system Python

### DIFF
--- a/drake_bazel_download/MODULE.bazel
+++ b/drake_bazel_download/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "rules_cc", version = "0.2.0")
 bazel_dep(name = "rules_python", version = "1.5.3")
 
 # Use the host system python.
-register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")
+register_toolchains("@rules_python//python/runtime_env_toolchains:all")
 
 # Disable the exec tools toolchain.
 register_toolchains("//:python_no_exec_tools_toolchain")


### PR DESCRIPTION
The prior spelling still works, but is deprecated.  See [v0.34.0 changelog](https://github.com/bazel-contrib/rules_python/blob/main/CHANGELOG.md#0340---2024-07-04); we were using the `@bazel_tools` vendored copy of that code, not the `@rules_python` copy, but the general principle still applies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/431)
<!-- Reviewable:end -->
