### PR TITLE
[drake_bazel_download] Use `user.bazelrc` in CI

### DIFF
--- a/drake_bazel_download/.github/ci_build_test
+++ b/drake_bazel_download/.github/ci_build_test
@@ -3,10 +3,12 @@
 
 set -euxo pipefail
 
+cat <<EOF > "user.bazelrc"
 # Use what we installed to $HOME/drake,
 # rather than the URL to the most recent nightly release
 # found in drake_bazel_download/MODULE.bazel.
-drake_override_flag="--override_repository=+_repo_rules2+drake=$HOME/drake"
+build --override_repository=+_repo_rules2+drake=$HOME/drake
+EOF
 
 # Setup $HOME/drake as a Bazel workspace via
 # BUILD and WORKSPACE files.
@@ -14,4 +16,4 @@ ln -sf $(realpath drake.BUILD.bazel) "$HOME/drake/BUILD.bazel"
 touch "$HOME/drake/WORKSPACE.bazel"
 
 bazel version
-bazel test "${drake_override_flag}" //...
+bazel test //...

--- a/drake_bazel_download/MODULE.bazel
+++ b/drake_bazel_download/MODULE.bazel
@@ -13,8 +13,8 @@ register_toolchains("@rules_python//python/runtime_env_toolchains:all")
 register_toolchains("//:python_no_exec_tools_toolchain")
 
 # Use the host system Eigen.
-local_eigen_repositiory = use_repo_rule("//:eigen.bzl", "local_eigen_repository")
-local_eigen_repositiory(name = "eigen")
+local_eigen_repository = use_repo_rule("//:eigen.bzl", "local_eigen_repository")
+local_eigen_repository(name = "eigen")
 
 # Use a downloaded, pre-compiled build of Drake.
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
88d4e32 added this for drake_bazel_external, but we should be consistent here. Also, fix a typo in `MODULE.bazel`.