### PR TITLE
Enable apple_support version bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,12 +22,6 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "apple_support"
-      ],
-      "enabled": false
-    },
-    {
       "matchManagers": [
         "pip_requirements",
         "poetry",


### PR DESCRIPTION
Closes #444 

Re-enable dependency management for `apple_support` BCR package.

See [here](https://github.com/Aiden2244/aiden2244-dee-clone/issues/1) for the renovate scan results as applied to an up-to-date clone of Drake External Examples on my personal GH account.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/445)
<!-- Reviewable:end -->
