### PR TITLE
[drake_cmake_external] Add private tests for static libdrake

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,11 @@ if (env.BRANCH_NAME == 'main') {
 
 properties(props)
 
-def examples = ['drake_bazel_external', 'drake_cmake_external']
+def examples = [
+  'drake_bazel_external',
+  'drake_cmake_external',
+  'private/drake_cmake_external_static'
+]
 def jobs = [:]
 
 for (example in examples) {

--- a/private/README.md
+++ b/private/README.md
@@ -2,3 +2,8 @@
 
 These files are for use by the Drake maintainers, and should not be
 copied into your own project(s).
+
+* `drake_cmake_external_static/`: A pared-down copy of the drake_cmake_external
+example in order to provide CI coverage of installing and linking libdrake
+statically.
+* `test/`: General testing utilities.

--- a/private/drake_cmake_external_static/.github/ci_build_test
+++ b/private/drake_cmake_external_static/.github/ci_build_test
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT-0
+
+set -euxo pipefail
+
+drake_commit_hash=
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --drake-commit-hash)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo 'No argument specified for --drake-commit-hash' >&2
+        exit 1
+      fi
+      drake_commit_hash="$1"
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 1
+  esac
+  shift
+done
+
+cmake --version
+
+mkdir build
+pushd build
+
+export LD_LIBRARY_PATH="${PWD}/install/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+cmake_args=()
+if [[ ! -z "${drake_commit_hash}" ]]; then
+  # Use a specific commit of Drake source,
+  # rather than the latest from master.
+  cmake_args+=(-DDRAKE_COMMIT_HASH=${drake_commit_hash})
+fi
+
+cmake .. "${cmake_args[@]}"
+cmake --build .
+
+cd drake_external_examples
+ctest -V .
+
+popd
+
+chmod -R a+w build || true
+rm -rf build

--- a/private/drake_cmake_external_static/.github/setup
+++ b/private/drake_cmake_external_static/.github/setup
@@ -1,0 +1,16 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT-0
+
+set -euxo pipefail
+
+# CI setup
+sudo .github/ubuntu_setup
+
+# drake source setup
+setup/install_prereqs "$@"
+
+# Provide regression coverage for the WITH_USER_...=ON options by un-installing
+# packages that should not be necessary in this particular build flavor. This
+# example configures them to be built from source.
+sudo apt-get remove libeigen3-dev libfmt-dev libspdlog-dev
+sudo apt-get autoremove

--- a/private/drake_cmake_external_static/.github/ubuntu_setup
+++ b/private/drake_cmake_external_static/.github/ubuntu_setup
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT-0
+
+set -euxo pipefail
+
+if [[ "${EUID:-}" -ne 0 ]]; then
+  echo 'This script must be run as root' >&2
+  exit 2
+fi
+
+echo 'APT::Acquire::Retries "4";' > /etc/apt/apt.conf.d/80-acquire-retries
+echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
+
+export DEBIAN_FRONTEND='noninteractive'
+
+apt-get update
+apt-get install --no-install-recommends lsb-release
+
+if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+  echo 'This script requires Ubuntu 24.04 (Noble)' >&2
+  exit 3
+fi

--- a/private/drake_cmake_external_static/CMakeLists.txt
+++ b/private/drake_cmake_external_static/CMakeLists.txt
@@ -1,10 +1,5 @@
 # SPDX-License-Identifier: MIT-0
 
-# TODO(eric.cousineau): Link to documentation on superproject example pending
-# resolution of: https://gitlab.kitware.com/cmake/cmake/issues/18336
-
-# See https://drake.mit.edu/from_source.html for the versions of CMake
-# officially supported by Drake when building from source.
 cmake_minimum_required(VERSION 3.22...4.0)
 project(drake_cmake_external)
 
@@ -28,9 +23,6 @@ list(APPEND CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}")
 
 include(ExternalProject)
 
-# This shows how to fetch Eigen from source as part of Drake's CMake build.
-# If you'd rather just use your operating system's Eigen, then this stanza could
-# be removed (as well as removing -DWITH_USER_EIGEN:BOOL=ON, below).
 ExternalProject_Add(eigen
   URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
   URL_HASH SHA256=8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72
@@ -60,10 +52,6 @@ ExternalProject_Add(eigen
   BUILD_ALWAYS ON
 )
 
-# This shows how to rebuild fmt from source as part of Drake's CMake build.
-# If you'd rather just use your operating system's fmt, then this stanza could
-# be removed (as well as removing -DWITH_USER_FMT:BOOL=ON, below).
-# If you rebuild fmt from source, then you must also rebuild spdlog from source.
 ExternalProject_Add(fmt
   URL https://github.com/fmtlib/fmt/archive/refs/tags/11.0.2.tar.gz
   URL_HASH SHA256=6cb1e6d37bdcb756dbbe59be438790db409cdb4868c66e888d5df9f13f7c027f
@@ -82,10 +70,6 @@ ExternalProject_Add(fmt
   BUILD_ALWAYS ON
 )
 
-# This shows how to rebuild spdlog from source as part of Drake's CMake build.
-# If you'd rather just use your operating system's fmt, then this stanza could
-# be removed (as well as removing -DWITH_USER_SPDLOG:BOOL=ON, below).
-# If you rebuild spdlog from source, then you must also rebuild fmt from source.
 ExternalProject_Add(spdlog
   DEPENDS fmt
   URL https://github.com/gabime/spdlog/archive/refs/tags/v1.15.0.tar.gz
@@ -104,14 +88,8 @@ ExternalProject_Add(spdlog
     -Dfmt_DIR=${CMAKE_INSTALL_PREFIX}/lib/cmake/fmt
 )
 
-# This is the external project PREFIX (not to be confused with the install
-# prefix) which will contain, among other things, the checkout of Drake's
-# source. This should match the default value, but for paranoia's sake, we'll
-# also pass this explicitly to ExternalProject_Add.
 set(DRAKE_PREFIX "${PROJECT_BINARY_DIR}/drake-prefix")
 
-# Options to override Drake's latest source on master with a specific commit.
-# See README.md for details.
 set(DRAKE_COMMIT_HASH "master" CACHE STRING "Commit hash for Drake")
 set(DRAKE_COMMIT_SHA256 CACHE STRING "SHA256 hash value for Drake commit archive")
 
@@ -135,16 +113,10 @@ ExternalProject_Add(drake
     -DWITH_USER_EIGEN:BOOL=ON
     -DWITH_USER_FMT:BOOL=ON
     -DWITH_USER_SPDLOG:BOOL=ON
-    # The Drake build has options to turn features on/off. For the full list,
-    # see https://drake.mit.edu/from_source.html. Here, we demonstrate how to
-    # set an arbitrary option for one of the open-source dependencies.
-    -DWITH_CSDP:BOOL=OFF
-    # The Drake build also supports installing a static drake::drake library,
-    # instead of shared (the default). This requires disabling installation of
-    # the Python-related tools, which rely on dynamic linking. To enable this
-    # option, uncomment the following lines.
-    # -DBUILD_SHARED_LIBS:BOOL=OFF
-    # -DDRAKE_INSTALL_PYTHON:BOOL=OFF
+    # Unlike the drake_cmake_external example, test the static library
+    # installation and linking here.
+    -DBUILD_SHARED_LIBS:BOOL=OFF
+    -DDRAKE_INSTALL_PYTHON:BOOL=OFF
   PREFIX "${DRAKE_PREFIX}"
   BINARY_DIR "${PROJECT_BINARY_DIR}/drake"
   BUILD_ALWAYS ON

--- a/private/drake_cmake_external_static/drake_external_examples/CMakeLists.txt
+++ b/private/drake_cmake_external_static/drake_external_examples/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT-0
+
+cmake_minimum_required(VERSION 3.16)
+project(drake_external_examples)
+
+find_package(drake CONFIG REQUIRED)
+
+add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
+target_link_libraries(simple_continuous_time_system drake::drake)
+
+include(CTest)
+
+add_test(NAME simple_continuous_time_system
+  COMMAND simple_continuous_time_system
+)

--- a/private/drake_cmake_external_static/drake_external_examples/simple_continuous_time_system.cc
+++ b/private/drake_cmake_external_static/drake_external_examples/simple_continuous_time_system.cc
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT-0
+
+// Simple Continuous Time System Example
+//
+// This is meant to be a sort of "hello world" example for the drake::system
+// classes. It defines a very simple continuous time system and simulates it
+// from a given initial condition.
+
+#include <cmath>
+
+#include <drake/common/drake_assert.h>
+#include <drake/systems/analysis/simulator.h>
+#include <drake/systems/framework/basic_vector.h>
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/continuous_state.h>
+#include <drake/systems/framework/leaf_system.h>
+
+namespace drake_external_examples {
+namespace systems {
+
+// Simple Continuous Time System
+//   xdot = -x + x³
+//   y = x
+class SimpleContinuousTimeSystem : public drake::systems::LeafSystem<double> {
+ public:
+  SimpleContinuousTimeSystem() {
+    DeclareVectorOutputPort("y", drake::systems::BasicVector<double>(1),
+                            &SimpleContinuousTimeSystem::CopyStateOut);
+    DeclareContinuousState(1);  // One state variable.
+  }
+
+ private:
+  // xdot = -x + x³
+  void DoCalcTimeDerivatives(
+      const drake::systems::Context<double>& context,
+      drake::systems::ContinuousState<double>* derivatives) const override {
+    const double x = context.get_continuous_state()[0];
+    const double xdot = -x + std::pow(x, 3.0);
+    (*derivatives)[0] = xdot;
+  }
+
+  // y = x
+  void CopyStateOut(const drake::systems::Context<double>& context,
+                    drake::systems::BasicVector<double>* output) const {
+    const double x = context.get_continuous_state()[0];
+    (*output)[0] = x;
+  }
+};
+
+}  // namespace systems
+}  // namespace drake_external_examples
+
+int main() {
+  // Create the simple system.
+  drake_external_examples::systems::SimpleContinuousTimeSystem system;
+
+  // Create the simulator.
+  drake::systems::Simulator<double> simulator(system);
+
+  // Set the initial conditions x(0).
+  drake::systems::ContinuousState<double>& state =
+      simulator.get_mutable_context().get_mutable_continuous_state();
+  state[0] = 0.9;
+
+  // Simulate for 10 seconds.
+  simulator.AdvanceTo(10);
+
+  // Make sure the simulation converges to the stable fixed point at x = 0.
+  DRAKE_DEMAND(state[0] < 1.0e-4);
+
+  return 0;
+}


### PR DESCRIPTION
Point users to the new `BUILD_SHARED_LIBS` and `DRAKE_INSTALL_PYTHON` CMake options. In order to provide CI coverage, rather than rewriting the example or adding a new one, add similar code under `private/`.

Towards RobotLocomotion/drake#16882, associated with / blocked by RobotLocomotion/drake#23298.