### PR TITLE
[drake_cmake_external] Set $CC in CI to enable warning suppressions

### DIFF
--- a/drake_cmake_external/.github/ci_build_test
+++ b/drake_cmake_external/.github/ci_build_test
@@ -22,6 +22,10 @@ while [ "${1:-}" != "" ]; do
   shift
 done
 
+# Use /usr/bin/gcc vs /usr/bin/cc to get proper warning suppressions.
+export CC=gcc
+export CXX=g++
+
 cmake --version
 
 mkdir build


### PR DESCRIPTION
See https://github.com/lcm-proj/lcm/blob/c752203d3ae89eba160c293b4ffcc2b81cb691a7/lcm-bazel/private/copts.bzl#L9-L13.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/472)
<!-- Reviewable:end -->
