### PR TITLE
Bump macOS to Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ on:
         description: 'Drake mac-arm-sequoia-*-packaging .tar.gz artifact URL'
         required: false
       linux_noble_wheel:
-        description: 'Drake linux-noble-*-wheel-*-release Python 3.10 artifact URL'
+        description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
       mac_arm_sequoia_wheel:
-        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.13 artifact URL'
+        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
@@ -53,7 +53,7 @@ jobs:
       - name: setup
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: file_sync test
         run: |
           pip install ruamel.yaml

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,7 +10,7 @@ jobs:
     name: macos sequoia 15 arm
     runs-on: macos-15
     env:
-      PYTHON_VERSION: '3.13'
+      PYTHON_VERSION: '3.14'
     steps:
       - name: checkout
         uses: actions/checkout@v5

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -10,7 +10,7 @@ jobs:
     name: macos sequoia 15 arm
     runs-on: macos-15
     env:
-      PYTHON_VERSION: '3.13'
+      PYTHON_VERSION: '3.14'
     steps:
       - name: checkout
         uses: actions/checkout@v5

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ on:
   workflow_dispatch:
     inputs:
       linux_noble_wheel:
-        description: 'Drake linux-noble-*-wheel-*-release Python 3.10 artifact URL'
+        description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
       mac_arm_sequoia_wheel:
-        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.13 artifact URL'
+        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
@@ -29,7 +29,7 @@ jobs:
     name: macos sequoia 15 arm
     runs-on: macos-15
     env:
-      PYTHON_VERSION: '3.13'
+      PYTHON_VERSION: '3.14'
     steps:
       - name: checkout
         uses: actions/checkout@v5

--- a/drake_pip/README.md
+++ b/drake_pip/README.md
@@ -43,10 +43,10 @@ setup/setup_env
 
 *Note*: If you have multiple versions of Python installed,
 you can specify the correct version as an optional argument
-to the script. For example, to use `python3.13`, call:
+to the script. For example, to use `python3.14`, call:
 
 ```bash
-setup/setup_env --python-version 3.13
+setup/setup_env --python-version 3.14
 ```
 
 Refer to the

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ on:
   workflow_dispatch:
     inputs:
       linux_noble_wheel:
-        description: 'Drake linux-noble-*-wheel-*-release Python 3.10 artifact URL'
+        description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
       mac_arm_sequoia_wheel:
-        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.13 artifact URL'
+        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.
@@ -29,7 +29,7 @@ jobs:
     name: macos sequoia 15 arm
     runs-on: macos-15
     env:
-      PYTHON_VERSION: '3.13'
+      PYTHON_VERSION: '3.14'
     steps:
       - name: checkout
         uses: actions/checkout@v5

--- a/drake_poetry/README.md
+++ b/drake_poetry/README.md
@@ -28,10 +28,10 @@ setup/install_prereqs
 
 *Note*: If you have multiple versions of Python installed,
 you can specify the correct version as an optional argument
-to the script. For example, to use `python3.13`, call:
+to the script. For example, to use `python3.14`, call:
 
 ```bash
-setup/setup_env --python-version 3.13
+setup/setup_env --python-version 3.14
 ```
 
 Refer to the


### PR DESCRIPTION
Also upgrade Drake to 1.47 so that 3.14 wheels are available.

Closes RobotLocomotion/drake#23592.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/473)
<!-- Reviewable:end -->
