### PR TITLE
Remove workaround for brew/setup-python conflict

### DIFF
--- a/.github/workflows/cmake_installed.yml
+++ b/.github/workflows/cmake_installed.yml
@@ -12,17 +12,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      # See issue https://github.com/actions/setup-python/issues/577.  There is
-      # some kind of environment conflict between the symlinks found in the
-      # GitHub Actions runner and `brew upgrade python` where `brew` detects and
-      # refuses to overwrite symlinks.  The cause for our runs is not clear,
-      # we do not use that action, but if that issue is closed this section
-      # can be removed.
-      - name: sanitize GHA / brew python environment
-        run: |
-          # Remove the symlinks that cause issues.
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
-          sudo rm -rf /Library/Frameworks/Python.framework/
       - name: setup
         working-directory: drake_cmake_installed
         run: |

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,17 +14,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      # See issue https://github.com/actions/setup-python/issues/577.  There is
-      # some kind of environment conflict between the symlinks found in the
-      # GitHub Actions runner and `brew upgrade python` where `brew` detects and
-      # refuses to overwrite symlinks.  The cause for our runs is not clear,
-      # we do not use that action, but if that issue is closed this section
-      # can be removed.
-      - name: sanitize GHA / brew python environment
-        run: |
-          # Remove the symlinks that cause issues.
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
-          sudo rm -rf /Library/Frameworks/Python.framework/
       - name: python setup
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -14,17 +14,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      # See issue https://github.com/actions/setup-python/issues/577.  There is
-      # some kind of environment conflict between the symlinks found in the
-      # GitHub Actions runner and `brew upgrade python` where `brew` detects and
-      # refuses to overwrite symlinks.  The cause for our runs is not clear,
-      # we do not use that action, but if that issue is closed this section
-      # can be removed.
-      - name: sanitize GHA / brew python environment
-        run: |
-          # Remove the symlinks that cause issues.
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
-          sudo rm -rf /Library/Frameworks/Python.framework/
       - name: python setup
         uses: actions/setup-python@v6
         with:

--- a/drake_cmake_installed/.github/workflows/ci.yml
+++ b/drake_cmake_installed/.github/workflows/ci.yml
@@ -31,17 +31,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      # See issue https://github.com/actions/setup-python/issues/577.  There is
-      # some kind of environment conflict between the symlinks found in the
-      # GitHub Actions runner and `brew upgrade python` where `brew` detects and
-      # refuses to overwrite symlinks.  The cause for our runs is not clear,
-      # we do not use that action, but if that issue is closed this section
-      # can be removed.
-      - name: sanitize GHA / brew python environment
-        run: |
-          # Remove the symlinks that cause issues.
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
-          sudo rm -rf /Library/Frameworks/Python.framework/
       - name: setup
         working-directory: drake_cmake_installed
         run: |

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -33,17 +33,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      # See issue https://github.com/actions/setup-python/issues/577.  There is
-      # some kind of environment conflict between the symlinks found in the
-      # GitHub Actions runner and `brew upgrade python` where `brew` detects and
-      # refuses to overwrite symlinks.  The cause for our runs is not clear,
-      # we do not use that action, but if that issue is closed this section
-      # can be removed.
-      - name: sanitize GHA / brew python environment
-        run: |
-          # Remove the symlinks that cause issues.
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
-          sudo rm -rf /Library/Frameworks/Python.framework/
       - name: python setup
         uses: actions/setup-python@v6
         with:

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -33,17 +33,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      # See issue https://github.com/actions/setup-python/issues/577.  There is
-      # some kind of environment conflict between the symlinks found in the
-      # GitHub Actions runner and `brew upgrade python` where `brew` detects and
-      # refuses to overwrite symlinks.  The cause for our runs is not clear,
-      # we do not use that action, but if that issue is closed this section
-      # can be removed.
-      - name: sanitize GHA / brew python environment
-        run: |
-          # Remove the symlinks that cause issues.
-          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
-          sudo rm -rf /Library/Frameworks/Python.framework/
       - name: python setup
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/9966 for the upstream change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/479)
<!-- Reviewable:end -->
