### PR TITLE
Reconfigure renovate.json to bump github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
----
-version: 2
-updates:
-  # This updates official GitHub Actions used in CI, e.g. actions/checkout,
-  # actions/setup-python.
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,13 +12,15 @@
     "pip_requirements",
     "poetry",
     "bazelisk",
-    "bazel-module"
+    "bazel-module",
+    "github-actions"
   ],
   "includePaths": [
     "drake_pip/**",
     "drake_poetry/**",
     "drake_bazel_download/**",
-    "drake_bazel_external/**"
+    "drake_bazel_external/**",
+    "**/.github/**"
   ],
   "packageRules": [
     {
@@ -26,7 +28,8 @@
         "pip_requirements",
         "poetry",
         "bazelisk",
-        "bazel-module"
+        "bazel-module",
+        "github-actions"
       ],
       "rangeStrategy": "bump"
     }


### PR DESCRIPTION
Closes #480 

Upgrades gh actions for all *.yml files under .github subdirectories.

Proof of concept: https://github.com/Aiden2244/aiden2244-dee-clone/issues/1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/481)
<!-- Reviewable:end -->
