### PR TITLE
[drake_bazel_external] Remove compiler_major flag

### DIFF
--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -27,14 +27,6 @@ build --action_env=CCACHE_DISABLE=1
 # https://github.com/RobotLocomotion/drake/blob/master/tools/flags/BUILD.bazel
 build --@drake//tools/flags:public_repo_default=pkgconfig
 
-# Pass along the compiler major version to Drake. This doesn't actually set or
-# change the compiler used for the build, but tells Drake's CC rules what
-# version to expect to tweak compiler- and version-specific flags accordingly.
-# In particular, many warnings are suppressed when using gcc-13 (the default
-# on Ubuntu 24.04 Noble). Adapt this flag to your system's compiler major
-# version as necessary.
-# build --@drake//tools/cc_toolchain:compiler_major=13
-
 # Drake supports the use of proprietary solvers for mathematical programs.
 # See https://drake.mit.edu/bazel.html#proprietary-solvers for more info
 # and details on how to set them up.

--- a/drake_bazel_external/.github/ci_build_test
+++ b/drake_bazel_external/.github/ci_build_test
@@ -8,10 +8,6 @@ cat <<EOF > "user.bazelrc"
 # rather than the URL to the latest Drake master branch
 # found in drake_bazel_external/MODULE.bazel.
 build --override_module=drake=drake
-
-# Pass along the compiler version to Drake
-# (as suggested in drake_bazel_external/.bazelrc).
-build --@drake//tools/cc_toolchain:compiler_major=$(gcc -dumpversion)
 EOF
 
 bazel version


### PR DESCRIPTION
Drake has removed this flag from its build upstream (see RobotLocomotion/drake#24360).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/526)
<!-- Reviewable:end -->
