### PR TITLE
Drop dependencies on lsb_release

### DIFF
--- a/drake_bazel_download/setup/install_prereqs
+++ b/drake_bazel_download/setup/install_prereqs
@@ -56,14 +56,12 @@ if [[ "${EUID}" -ne 0 ]]; then
   maybe_sudo=sudo
 fi
 
-${maybe_sudo} apt-get update
-${maybe_sudo} apt-get install --no-install-recommends lsb-release
-
-if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+if [[ "$(. /etc/os-release && echo ${VERSION_CODENAME})" != 'noble' ]]; then
   echo 'This script requires Ubuntu 24.04 (Noble)' >&2
   exit 3
 fi
 
+${maybe_sudo} apt-get update
 ${maybe_sudo} apt-get install --no-install-recommends $(cat <<EOF
   ca-certificates
   wget

--- a/drake_bazel_external/.github/ubuntu_setup
+++ b/drake_bazel_external/.github/ubuntu_setup
@@ -13,10 +13,7 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-apt-get update
-apt-get install --no-install-recommends lsb-release
-
-if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+if [[ "$(. /etc/os-release && echo ${VERSION_CODENAME})" != 'noble' ]]; then
   echo 'This script requires Ubuntu 24.04 (Noble)' >&2
   exit 3
 fi

--- a/drake_cmake_external/.github/ubuntu_setup
+++ b/drake_cmake_external/.github/ubuntu_setup
@@ -13,10 +13,7 @@ echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-get-assume-yes
 
 export DEBIAN_FRONTEND='noninteractive'
 
-apt-get update
-apt-get install --no-install-recommends lsb-release
-
-if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+if [[ "$(. /etc/os-release && echo ${VERSION_CODENAME})" != 'noble' ]]; then
   echo 'This script requires Ubuntu 24.04 (Noble)' >&2
   exit 3
 fi

--- a/drake_cmake_installed/setup/install_prereqs
+++ b/drake_cmake_installed/setup/install_prereqs
@@ -46,14 +46,12 @@ case "$OSTYPE" in
       maybe_sudo=sudo
     fi
 
-    ${maybe_sudo} apt-get update
-    ${maybe_sudo} apt-get install --no-install-recommends lsb-release
-
-    if [[ "$(lsb_release -sc)" != 'noble' ]]; then
+    if [[ "$(. /etc/os-release && echo ${VERSION_CODENAME})" != 'noble' ]]; then
       echo 'This script requires Ubuntu 24.04 (Noble)' >&2
       exit 3
     fi
 
+    ${maybe_sudo} apt-get update
     ${maybe_sudo} apt-get install --no-install-recommends $(cat <<EOF
       ca-certificates
       wget


### PR DESCRIPTION
LSB has been long deprecated; port to the modern alternative of reading the `/etc/os-release` file directly.

Closes RobotLocomotion/drake#24268.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/531)
<!-- Reviewable:end -->
