### PR TITLE
[drake_bazel_external] Use lld for linking

### DIFF
--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -30,6 +30,11 @@ build --action_env=CCACHE_DISABLE=1
 # https://github.com/RobotLocomotion/drake/blob/master/tools/flags/BUILD.bazel
 build --@drake//tools/flags:public_repo_default=pkgconfig
 
+# On Linux we expected to be using -fuse-ld=lld to link (per @rules_cc), so we
+# must dial back its default per-process thread count of 16 down to something
+# less likely to overload the system.
+build:linux --linkopt=-Wl,--threads=1
+
 # Enable OpenMP (linux only).
 build:linux --copt=-DEIGEN_DONT_PARALLELIZE
 build:linux --copt=-fopenmp

--- a/drake_bazel_external/setup/install_prereqs
+++ b/drake_bazel_external/setup/install_prereqs
@@ -42,3 +42,7 @@ mkdir -p drake && tar -xf drake.tar.gz -C drake --strip-components 1
 
 # Install the source distribution prereqs.
 drake/setup/install_prereqs
+
+# Get ahead of a new dependency that will be added in Drake v1.53.0.
+# TODO(jwnimmer-tri) Remove after Drake v1.53.0 has been released.
+${maybe_sudo} apt-get install --no-install-recommends lld


### PR DESCRIPTION
The default linker on Noble ("gold") is unsuitable for Rust code.

This PR is a sibling of https://github.com/RobotLocomotion/drake/pull/24442.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/539)
<!-- Reviewable:end -->
