### PR TITLE
Fail fast on deprecations

### DIFF
--- a/drake_bazel_download/.bazelrc
+++ b/drake_bazel_download/.bazelrc
@@ -24,6 +24,10 @@ build --test_summary=terse
 # project.
 build --copt=-Werror=deprecated-declarations
 build --test_env=DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+# PYTHONWARNINGS populates Python's sys.warnoptions so that test runners like
+# unittest don't reset the warnings filter and thereby silently disable the
+# DRAKE_DEPRECATION_RUNTIME_SEVERITY=error behavior set up by pydrake.
+build --test_env=PYTHONWARNINGS=default
 
 # Use C++23.
 build --cxxopt=-std=c++23

--- a/drake_bazel_download/.bazelrc
+++ b/drake_bazel_download/.bazelrc
@@ -17,6 +17,14 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
+# Treat any use of a deprecated Drake API as a hard error: the copt fails
+# the C++ compile, and the test_env makes pydrake throw at the call site.
+# We set these in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove them or set to 'ignore' in your own
+# project.
+build --copt=-Werror=deprecated-declarations
+build --test_env=DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+
 # Use C++23.
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23

--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -24,6 +24,10 @@ build --test_summary=terse
 # project.
 build --copt=-Werror=deprecated-declarations
 build --test_env=DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+# PYTHONWARNINGS populates Python's sys.warnoptions so that test runners like
+# unittest don't reset the warnings filter and thereby silently disable the
+# DRAKE_DEPRECATION_RUNTIME_SEVERITY=error behavior set up by pydrake.
+build --test_env=PYTHONWARNINGS=default
 
 # Use C++23.
 build --cxxopt=-std=c++23

--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -17,6 +17,14 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
+# Treat any use of a deprecated Drake API as a hard error: the copt fails
+# the C++ compile, and the test_env makes pydrake throw at the call site.
+# We set these in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove them or set to 'ignore' in your own
+# project.
+build --copt=-Werror=deprecated-declarations
+build --test_env=DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+
 # Use C++23.
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23

--- a/drake_cmake_external/drake_external_examples/CMakeLists.txt
+++ b/drake_cmake_external/drake_external_examples/CMakeLists.txt
@@ -25,17 +25,23 @@ add_test(NAME simple_continuous_time_system
 add_test(NAME import_all_test COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/import_all_test.py"
 )
-set_tests_properties(import_all_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+set_property(TEST import_all_test APPEND PROPERTY ENVIRONMENT
+  "PYTHONPATH=${drake_PYTHON_DIR}"
+  "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+  "PYTHONWARNINGS=default"
 )
 
 add_test(NAME solver_disabled_test
   COMMAND Python3::Interpreter -B -m unittest solver_disabled_test
 )
 set_tests_properties(solver_disabled_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/solver_disabled_test.py"
   TIMEOUT 60
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+set_property(TEST solver_disabled_test APPEND PROPERTY ENVIRONMENT
+  "PYTHONPATH=${drake_PYTHON_DIR}"
+  "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+  "PYTHONWARNINGS=default"
 )

--- a/drake_cmake_external/drake_external_examples/CMakeLists.txt
+++ b/drake_cmake_external/drake_external_examples/CMakeLists.txt
@@ -7,6 +7,13 @@ find_package(drake CONFIG REQUIRED)
 
 find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 
+# Treat any use of a deprecated Drake API as a hard error: the compile flag
+# fails the C++ compile, and the test environment makes pydrake throw at the
+# call site. We set these in our examples to ensure they stay up-to-date with
+# latest Drake. You might decide to remove them or set to 'ignore' in your own
+# project.
+add_compile_options(-Werror=deprecated-declarations)
+
 add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
 target_link_libraries(simple_continuous_time_system drake::drake)
 
@@ -19,14 +26,14 @@ add_test(NAME import_all_test COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/import_all_test.py"
 )
 set_tests_properties(import_all_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
+  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
 )
 
 add_test(NAME solver_disabled_test
   COMMAND Python3::Interpreter -B -m unittest solver_disabled_test
 )
 set_tests_properties(solver_disabled_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
+  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/solver_disabled_test.py"
   TIMEOUT 60

--- a/drake_cmake_installed/src/CMakeLists.txt
+++ b/drake_cmake_installed/src/CMakeLists.txt
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: MIT-0
 
+# Treat any use of a deprecated Drake API as a hard error: the compile flag
+# fails the C++ compile, and the test environment (set per-test below)
+# makes pydrake throw at the call site. We set these in our examples to
+# ensure they stay up-to-date with latest Drake. You might decide to remove
+# them or set to 'ignore' in your own project.
+add_compile_options(-Werror=deprecated-declarations)
+
 add_subdirectory(find_resource)
 add_subdirectory(particle)
 add_subdirectory(simple_bindings)
@@ -9,5 +16,5 @@ add_test(NAME import_all_test COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/import_all_test.py"
 )
 set_tests_properties(import_all_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
+  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
 )

--- a/drake_cmake_installed/src/CMakeLists.txt
+++ b/drake_cmake_installed/src/CMakeLists.txt
@@ -15,6 +15,8 @@ add_subdirectory(simple_continuous_time_system)
 add_test(NAME import_all_test COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/import_all_test.py"
 )
-set_tests_properties(import_all_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+set_property(TEST import_all_test APPEND PROPERTY ENVIRONMENT
+  "PYTHONPATH=${drake_PYTHON_DIR}"
+  "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+  "PYTHONWARNINGS=default"
 )

--- a/drake_cmake_installed/src/find_resource/CMakeLists.txt
+++ b/drake_cmake_installed/src/find_resource/CMakeLists.txt
@@ -8,5 +8,5 @@ add_test(NAME find_resource_example_py COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/find_resource_example.py"
 )
 set_tests_properties(find_resource_example_py PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
+  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
 )

--- a/drake_cmake_installed/src/find_resource/CMakeLists.txt
+++ b/drake_cmake_installed/src/find_resource/CMakeLists.txt
@@ -7,6 +7,8 @@ add_test(NAME find_resource_example COMMAND find_resource_example)
 add_test(NAME find_resource_example_py COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/find_resource_example.py"
 )
-set_tests_properties(find_resource_example_py PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+set_property(TEST find_resource_example_py APPEND PROPERTY ENVIRONMENT
+  "PYTHONPATH=${drake_PYTHON_DIR}"
+  "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+  "PYTHONWARNINGS=default"
 )

--- a/drake_cmake_installed/src/particle/CMakeLists.txt
+++ b/drake_cmake_installed/src/particle/CMakeLists.txt
@@ -12,9 +12,13 @@ add_test(NAME python_particle_test
   COMMAND Python3::Interpreter -B -m unittest particle_test
 )
 set_tests_properties(python_particle_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/particle_test.py"
   TIMEOUT 60
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+set_property(TEST python_particle_test APPEND PROPERTY ENVIRONMENT
+  "PYTHONPATH=${drake_PYTHON_DIR}"
+  "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+  "PYTHONWARNINGS=default"
 )

--- a/drake_cmake_installed/src/particle/CMakeLists.txt
+++ b/drake_cmake_installed/src/particle/CMakeLists.txt
@@ -12,7 +12,7 @@ add_test(NAME python_particle_test
   COMMAND Python3::Interpreter -B -m unittest particle_test
 )
 set_tests_properties(python_particle_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
+  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/particle_test.py"
   TIMEOUT 60

--- a/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
@@ -18,4 +18,4 @@ add_test(NAME simple_bindings_test COMMAND
     "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/simple_bindings_test.py")
 set_tests_properties(simple_bindings_test PROPERTIES
     # Using `pybind11/tests/test_cmake_build/installed_target` as an example.
-    ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:simple_bindings>:${drake_PYTHON_DIR}")
+    ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:simple_bindings>:${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error")

--- a/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
@@ -16,6 +16,9 @@ set_target_properties(simple_bindings PROPERTIES CXX_VISIBILITY_PRESET default)
 
 add_test(NAME simple_bindings_test COMMAND
     "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/simple_bindings_test.py")
-set_tests_properties(simple_bindings_test PROPERTIES
-    # Using `pybind11/tests/test_cmake_build/installed_target` as an example.
-    ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:simple_bindings>:${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error")
+# Using `pybind11/tests/test_cmake_build/installed_target` as an example.
+set_property(TEST simple_bindings_test APPEND PROPERTY ENVIRONMENT
+    "PYTHONPATH=$<TARGET_FILE_DIR:simple_bindings>:${drake_PYTHON_DIR}"
+    "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+    "PYTHONWARNINGS=default"
+)

--- a/drake_cmake_installed_apt/CMakeLists.txt
+++ b/drake_cmake_installed_apt/CMakeLists.txt
@@ -24,4 +24,12 @@ target_link_libraries(gtest Threads::Threads)
 find_package(drake CONFIG REQUIRED PATHS /opt/drake)
 find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 
+# Treat any use of a deprecated Drake API as a hard error: the compile flag
+# fails the C++ compile, and the test environment (set per-test in src/)
+# makes pydrake throw at the call site. We set these in our examples to
+# ensure they stay up-to-date with latest Drake. You might decide to remove
+# them or set to 'ignore' in your own project. Applied here (after the gtest
+# target) so it scopes only to our own example sources.
+add_compile_options(-Werror=deprecated-declarations)
+
 add_subdirectory(src)

--- a/drake_cmake_installed_apt/src/CMakeLists.txt
+++ b/drake_cmake_installed_apt/src/CMakeLists.txt
@@ -12,9 +12,13 @@ add_test(NAME python_particle_test
   COMMAND Python3::Interpreter -B -m unittest particle_test
 )
 set_tests_properties(python_particle_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/particle_test.py"
   TIMEOUT 60
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+set_property(TEST python_particle_test APPEND PROPERTY ENVIRONMENT
+  "PYTHONPATH=${drake_PYTHON_DIR}"
+  "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+  "PYTHONWARNINGS=default"
 )

--- a/drake_cmake_installed_apt/src/CMakeLists.txt
+++ b/drake_cmake_installed_apt/src/CMakeLists.txt
@@ -12,7 +12,7 @@ add_test(NAME python_particle_test
   COMMAND Python3::Interpreter -B -m unittest particle_test
 )
 set_tests_properties(python_particle_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
+  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR};DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/particle_test.py"
   TIMEOUT 60


### PR DESCRIPTION
Related: https://github.com/RobotLocomotion/drake-external-examples/issues/159

Modifies the python and C++ examples to error if a deprecated drake API is used

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/546)
<!-- Reviewable:end -->
