### PR TITLE
Drop platform-specific names on macOS CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ on:
       linux_noble_package_deb:
         description: 'Drake linux-noble-*-packaging .deb artifact URL'
         required: false
-      mac_arm_sequoia_package_tar:
+      mac_package_tar:
         description: 'Drake mac-arm-sequoia-*-packaging .tar.gz artifact URL'
         required: false
-      linux_noble_wheel:
+      linux_wheel:
         description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
-      mac_arm_sequoia_wheel:
+      mac_wheel:
         description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:

--- a/.github/workflows/cmake_installed.yml
+++ b/.github/workflows/cmake_installed.yml
@@ -6,8 +6,8 @@ on:
   workflow_call:
 
 jobs:
-  macos_sequoia_arm_cmake_installed:
-    name: macos sequoia 15 arm
+  macos_cmake_installed:
+    name: macos
     runs-on: macos-15
     steps:
       - name: checkout
@@ -16,8 +16,8 @@ jobs:
         working-directory: drake_cmake_installed
         run: |
           args=()
-          if [[ '${{ github.event.inputs.mac_arm_sequoia_package_tar }}' != '' ]]; then
-            args+=(--package-url ${{ github.event.inputs.mac_arm_sequoia_package_tar }})
+          if [[ '${{ github.event.inputs.mac_package_tar }}' != '' ]]; then
+            args+=(--package-url ${{ github.event.inputs.mac_package_tar }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -6,8 +6,8 @@ on:
   workflow_call:
 
 jobs:
-  macos_sequoia_arm_pip:
-    name: macos sequoia 15 arm
+  macos_pip:
+    name: macos
     runs-on: macos-15
     env:
       PYTHON_VERSION: '3.14'
@@ -22,8 +22,8 @@ jobs:
         working-directory: drake_pip
         run: |
           args=(--python-version $PYTHON_VERSION)
-          if [[ '${{ github.event.inputs.mac_arm_sequoia_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sequoia_wheel }})
+          if [[ '${{ github.event.inputs.mac_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.mac_wheel }})
           fi
           setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
@@ -42,8 +42,8 @@ jobs:
         working-directory: drake_pip
         run: |
           args=()
-          if [[ '${{ github.event.inputs.linux_noble_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.linux_noble_wheel }})
+          if [[ '${{ github.event.inputs.linux_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.linux_wheel }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -6,8 +6,8 @@ on:
   workflow_call:
 
 jobs:
-  macos_sequoia_arm_poetry:
-    name: macos sequoia 15 arm
+  macos_poetry:
+    name: macos
     runs-on: macos-15
     env:
       PYTHON_VERSION: '3.14'
@@ -23,8 +23,8 @@ jobs:
         run: |
           .github/setup
           args=(--python-version $PYTHON_VERSION)
-          if [[ '${{ github.event.inputs.mac_arm_sequoia_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sequoia_wheel }})
+          if [[ '${{ github.event.inputs.mac_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.mac_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -48,8 +48,8 @@ jobs:
           .github/setup
           source $HOME/.profile
           args=()
-          if [[ '${{ github.event.inputs.linux_noble_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.linux_noble_wheel }})
+          if [[ '${{ github.event.inputs.linux_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.linux_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
           .github/ci_build_test

--- a/drake_cmake_installed/.github/workflows/ci.yml
+++ b/drake_cmake_installed/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       linux_noble_package_tar:
         description: 'Drake linux-noble-*-packaging .tar.gz artifact URL'
         required: false
-      mac_arm_sequoia_package_tar:
+      mac_package_tar:
         description: 'Drake mac-arm-sequoia-*-packaging .tar.gz artifact URL'
         required: false
 concurrency:
@@ -25,8 +25,8 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  macos_sequoia_arm_cmake_installed:
-    name: macos sequoia 15 arm
+  macos_cmake_installed:
+    name: macos
     runs-on: macos-15
     steps:
       - name: checkout
@@ -35,8 +35,8 @@ jobs:
         working-directory: drake_cmake_installed
         run: |
           args=()
-          if [[ '${{ github.event.inputs.mac_arm_sequoia_package_tar }}' != '' ]]; then
-            args+=(--package-url ${{ github.event.inputs.mac_arm_sequoia_package_tar }})
+          if [[ '${{ github.event.inputs.mac_package_tar }}' != '' ]]; then
+            args+=(--package-url ${{ github.event.inputs.mac_package_tar }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
-      linux_noble_wheel:
+      linux_wheel:
         description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
-      mac_arm_sequoia_wheel:
+      mac_wheel:
         description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
@@ -25,8 +25,8 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  macos_sequoia_arm_pip:
-    name: macos sequoia 15 arm
+  macos_pip:
+    name: macos
     runs-on: macos-15
     env:
       PYTHON_VERSION: '3.14'
@@ -41,8 +41,8 @@ jobs:
         working-directory: drake_pip
         run: |
           args=(--python-version $PYTHON_VERSION)
-          if [[ '${{ github.event.inputs.mac_arm_sequoia_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sequoia_wheel }})
+          if [[ '${{ github.event.inputs.mac_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.mac_wheel }})
           fi
           setup/setup_env "${args[@]}"
         shell: zsh -eufo pipefail {0}
@@ -61,8 +61,8 @@ jobs:
         working-directory: drake_pip
         run: |
           args=()
-          if [[ '${{ github.event.inputs.linux_noble_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.linux_noble_wheel }})
+          if [[ '${{ github.event.inputs.linux_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.linux_wheel }})
           fi
           .github/ubuntu_setup "${args[@]}"
         shell: bash

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
-      linux_noble_wheel:
+      linux_wheel:
         description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
-      mac_arm_sequoia_wheel:
+      mac_wheel:
         description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
@@ -25,8 +25,8 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  macos_sequoia_arm_poetry:
-    name: macos sequoia 15 arm
+  macos_poetry:
+    name: macos
     runs-on: macos-15
     env:
       PYTHON_VERSION: '3.14'
@@ -42,8 +42,8 @@ jobs:
         run: |
           .github/setup
           args=(--python-version $PYTHON_VERSION)
-          if [[ '${{ github.event.inputs.mac_arm_sequoia_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.mac_arm_sequoia_wheel }})
+          if [[ '${{ github.event.inputs.mac_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.mac_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
         shell: zsh -efuo pipefail {0}
@@ -67,8 +67,8 @@ jobs:
           .github/setup
           source $HOME/.profile
           args=()
-          if [[ '${{ github.event.inputs.linux_noble_wheel }}' != '' ]]; then
-            args+=(--wheel-url ${{ github.event.inputs.linux_noble_wheel }})
+          if [[ '${{ github.event.inputs.linux_wheel }}' != '' ]]; then
+            args+=(--wheel-url ${{ github.event.inputs.linux_wheel }})
           fi
           setup/install_prereqs "${args[@]}"
           .github/ci_build_test

--- a/private/test/file_sync_test.py
+++ b/private/test/file_sync_test.py
@@ -89,18 +89,18 @@ GITHUB_WORKFLOW_OPTS = {
     ),
     "cmake_installed": (
         "linux_noble_package_tar",
-        "mac_arm_sequoia_package_tar"
+        "mac_package_tar"
     ),
     "cmake_installed_apt": (
         "linux_noble_package_deb",
     ),
     "pip": (
-        "linux_noble_wheel",
-        "mac_arm_sequoia_wheel"
+        "linux_wheel",
+        "mac_wheel"
     ),
     "poetry": (
-        "linux_noble_wheel",
-        "mac_arm_sequoia_wheel"
+        "linux_wheel",
+        "mac_wheel"
     )
 }
 


### PR DESCRIPTION
This prepares for a change where macOS CI running on Tahoe may be using Drake packages that were built on Sequoia (see: #547).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/550)
<!-- Reviewable:end -->
