### PR TITLE
Fail fast on C++ deprecated API usage

### DIFF
--- a/drake_bazel_download/.bazelrc
+++ b/drake_bazel_download/.bazelrc
@@ -17,6 +17,13 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
+# Treat any use of a deprecated Drake C++ API as a hard compile error.
+# We set this in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove this or ignore deprecation warnings
+# in your own project.
+build --copt=-Werror=deprecated-declarations
+build --host_copt=-Werror=deprecated-declarations
+
 # Use C++23.
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23

--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -17,6 +17,13 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
+# Treat any use of a deprecated Drake C++ API as a hard compile error.
+# We set this in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove this or ignore deprecation warnings
+# in your own project.
+build --copt=-Werror=deprecated-declarations
+build --host_copt=-Werror=deprecated-declarations
+
 # Use C++23.
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23

--- a/drake_cmake_external/CMakeLists.txt
+++ b/drake_cmake_external/CMakeLists.txt
@@ -24,6 +24,12 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}")
 
+# Treat any use of a deprecated Drake C++ API as a hard compile error.
+# We set this in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove this or ignore deprecation warnings
+# in your own project.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=deprecated-declarations")
+
 include(ExternalProject)
 
 # This shows how to fetch Eigen from source as part of Drake's CMake build.

--- a/drake_cmake_installed/src/CMakeLists.txt
+++ b/drake_cmake_installed/src/CMakeLists.txt
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: MIT-0
 
+# Treat any use of a deprecated Drake C++ API as a hard compile error.
+# We set this in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove this or ignore deprecation warnings
+# in your own project.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=deprecated-declarations")
+
 add_subdirectory(find_resource)
 add_subdirectory(particle)
 add_subdirectory(simple_bindings)

--- a/drake_cmake_installed_apt/src/CMakeLists.txt
+++ b/drake_cmake_installed_apt/src/CMakeLists.txt
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: MIT-0
 
+# Treat any use of a deprecated Drake C++ API as a hard compile error.
+# We set this in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove this or ignore deprecation warnings
+# in your own project.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=deprecated-declarations")
+
 add_library(particle particle.cc particle.h)
 target_link_libraries(particle drake::drake)
 


### PR DESCRIPTION
Related: https://github.com/RobotLocomotion/drake-external-examples/issues/159, https://github.com/RobotLocomotion/drake-external-examples/pull/546

Modifies the C++ examples to error if a deprecated drake API is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/552)
<!-- Reviewable:end -->
