### PR TITLE
Fail fast on C++ deprecated API usage

### DIFF
--- a/drake_bazel_download/.bazelrc
+++ b/drake_bazel_download/.bazelrc
@@ -17,6 +17,13 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
+# Treat any use of a deprecated Drake C++ API as a hard compile error.
+# We set this in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove this or ignore deprecation warnings
+# in your own project.
+build --copt=-Werror=deprecated-declarations
+build --host_copt=-Werror=deprecated-declarations
+
 # Use C++23.
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23

--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -17,6 +17,13 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
+# Treat any use of a deprecated Drake C++ API as a hard compile error.
+# We set this in our examples to ensure they stay up-to-date with latest
+# Drake. You might decide to remove this or ignore deprecation warnings
+# in your own project.
+build --copt=-Werror=deprecated-declarations
+build --host_copt=-Werror=deprecated-declarations
+
 # Use C++23.
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23

--- a/drake_cmake_external/drake_external_examples/CMakeLists.txt
+++ b/drake_cmake_external/drake_external_examples/CMakeLists.txt
@@ -7,8 +7,24 @@ find_package(drake CONFIG REQUIRED)
 
 find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 
-add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
-target_link_libraries(simple_continuous_time_system drake::drake)
+# Drake target configuration wrappers that set common toolchain-related
+# semantics (linking drake::drake, deprecation policy) across the example
+# targets in this project.
+function(drake_example_add_executable target)
+  add_executable(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  # Treat any use of a deprecated Drake C++ API as a hard compile error.
+  # You might decide to ignore deprecation warnings in your own project.
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_add_library target)
+  add_library(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+drake_example_add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
 
 include(CTest)
 

--- a/drake_cmake_installed/CMakeLists.txt
+++ b/drake_cmake_installed/CMakeLists.txt
@@ -14,5 +14,28 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Drake target configuration wrappers that set common toolchain-related
+# semantics (linking drake::drake, deprecation policy) across the example
+# targets in this project.
+function(drake_example_add_executable target)
+  add_executable(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  # Treat any use of a deprecated Drake C++ API as a hard compile error.
+  # You might decide to ignore deprecation warnings in your own project.
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_add_library target)
+  add_library(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_pybind11_add_module target)
+  pybind11_add_module(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
 add_subdirectory(src)
 add_subdirectory(third_party)

--- a/drake_cmake_installed/src/find_resource/CMakeLists.txt
+++ b/drake_cmake_installed/src/find_resource/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-add_executable(find_resource_example find_resource_example.cc)
-target_link_libraries(find_resource_example drake::drake)
+drake_example_add_executable(find_resource_example find_resource_example.cc)
 add_test(NAME find_resource_example COMMAND find_resource_example)
 
 add_test(NAME find_resource_example_py COMMAND

--- a/drake_cmake_installed/src/particle/CMakeLists.txt
+++ b/drake_cmake_installed/src/particle/CMakeLists.txt
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MIT-0
 
-add_library(particle particle.cc particle.h)
-target_link_libraries(particle drake::drake)
+drake_example_add_library(particle particle.cc particle.h)
 
-add_executable(particle_test particle_test.cc)
-target_link_libraries(particle_test particle drake::drake gtest)
+drake_example_add_executable(particle_test particle_test.cc)
+target_link_libraries(particle_test PUBLIC particle gtest)
 add_test(NAME cc_particle_test COMMAND particle_test)
 set_tests_properties(cc_particle_test PROPERTIES LABELS small TIMEOUT 60)
 

--- a/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
@@ -2,8 +2,7 @@
 
 find_package(pybind11 CONFIG REQUIRED)
 
-pybind11_add_module(simple_bindings MODULE simple_bindings.cc)
-target_link_libraries(simple_bindings PUBLIC drake::drake)
+drake_example_pybind11_add_module(simple_bindings MODULE simple_bindings.cc)
 # N.B. `pybind11_add_module` normally sets the default visibility to "hidden"
 # to avoid warnings. However, we need the default visibility to be public so
 # template instantions that are bound in Python (e.g. `drake::Value<>`)

--- a/drake_cmake_installed/src/simple_continuous_time_system/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_continuous_time_system/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
-target_link_libraries(simple_continuous_time_system drake::drake)
+drake_example_add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
 add_test(NAME simple_continuous_time_system
   COMMAND simple_continuous_time_system
 )

--- a/drake_cmake_installed_apt/CMakeLists.txt
+++ b/drake_cmake_installed_apt/CMakeLists.txt
@@ -24,4 +24,21 @@ target_link_libraries(gtest Threads::Threads)
 find_package(drake CONFIG REQUIRED PATHS /opt/drake)
 find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 
+# Drake target configuration wrappers that set common toolchain-related
+# semantics (linking drake::drake, deprecation policy) across the example
+# targets in this project.
+function(drake_example_add_executable target)
+  add_executable(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  # Treat any use of a deprecated Drake C++ API as a hard compile error.
+  # You might decide to ignore deprecation warnings in your own project.
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_add_library target)
+  add_library(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
 add_subdirectory(src)

--- a/drake_cmake_installed_apt/src/CMakeLists.txt
+++ b/drake_cmake_installed_apt/src/CMakeLists.txt
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MIT-0
 
-add_library(particle particle.cc particle.h)
-target_link_libraries(particle drake::drake)
+drake_example_add_library(particle particle.cc particle.h)
 
-add_executable(particle_test particle_test.cc)
-target_link_libraries(particle_test particle drake::drake gtest)
+drake_example_add_executable(particle_test particle_test.cc)
+target_link_libraries(particle_test PUBLIC particle gtest)
 add_test(NAME cc_particle_test COMMAND particle_test)
 set_tests_properties(cc_particle_test PROPERTIES LABELS small TIMEOUT 60)
 


### PR DESCRIPTION
Reverts the revert of https://github.com/RobotLocomotion/drake-external-examples/pull/555 and propagates `-Werror=deprecated-declarations` properly in the cmake examples.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/556)
<!-- Reviewable:end -->
