### PR TITLE
Promote python warnings to errors

### DIFF
--- a/drake_bazel_download/.bazelrc
+++ b/drake_bazel_download/.bazelrc
@@ -17,12 +17,17 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
-# Treat any use of a deprecated Drake C++ API as a hard compile error.
-# We set this in our examples to ensure they stay up-to-date with latest
-# Drake. You might decide to remove this or ignore deprecation warnings
-# in your own project.
+# Treat any use of a deprecated Drake API as an error. On the C++ side,
+# -Werror=deprecated-declarations provides compile-time assertions. On the
+# Python side, PYTHONWARNINGS=error promotes all warnings to errors
+# (including deprecation warnings from pydrake). We set these in our
+# examples to ensure they stay up-to-date with latest Drake. You might
+# decide to remove these or ignore deprecation warnings in your own
+# project.
 build --copt=-Werror=deprecated-declarations
 build --host_copt=-Werror=deprecated-declarations
+build --test_env=DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+build --test_env=PYTHONWARNINGS=error
 
 # Use C++23.
 build --cxxopt=-std=c++23

--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -17,12 +17,17 @@ build --strip=never
 build --test_output=errors
 build --test_summary=terse
 
-# Treat any use of a deprecated Drake C++ API as a hard compile error.
-# We set this in our examples to ensure they stay up-to-date with latest
-# Drake. You might decide to remove this or ignore deprecation warnings
-# in your own project.
+# Treat any use of a deprecated Drake API as an error. On the C++ side,
+# -Werror=deprecated-declarations provides compile-time assertions. On the
+# Python side, PYTHONWARNINGS=error promotes all warnings to errors
+# (including deprecation warnings from pydrake). We set these in our
+# examples to ensure they stay up-to-date with latest Drake. You might
+# decide to remove these or ignore deprecation warnings in your own
+# project.
 build --copt=-Werror=deprecated-declarations
 build --host_copt=-Werror=deprecated-declarations
+build --test_env=DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+build --test_env=PYTHONWARNINGS=error
 
 # Use C++23.
 build --cxxopt=-std=c++23

--- a/drake_cmake_external/drake_external_examples/CMakeLists.txt
+++ b/drake_cmake_external/drake_external_examples/CMakeLists.txt
@@ -27,22 +27,19 @@ endfunction()
 drake_example_add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
 
 include(CTest)
+include(cmake/drake_example_add_test.cmake)
 
-add_test(NAME simple_continuous_time_system
+drake_example_add_cc_test(NAME simple_continuous_time_system
   COMMAND simple_continuous_time_system
 )
-add_test(NAME import_all_test COMMAND
+drake_example_add_py_test(NAME import_all_test COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/import_all_test.py"
 )
-set_tests_properties(import_all_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
-)
 
-add_test(NAME solver_disabled_test
+drake_example_add_py_test(NAME solver_disabled_test
   COMMAND Python3::Interpreter -B -m unittest solver_disabled_test
 )
 set_tests_properties(solver_disabled_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/solver_disabled_test.py"
   TIMEOUT 60

--- a/drake_cmake_external/drake_external_examples/cmake/drake_example_add_test.cmake
+++ b/drake_cmake_external/drake_external_examples/cmake/drake_example_add_test.cmake
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT-0
+
+include_guard(GLOBAL)
+
+# Wrapper around CMake's add_test() for Python example tests. In addition
+# to registering the test, it sets common environment defaults:
+#   PYTHONPATH so pydrake imports resolve.
+#   DRAKE_DEPRECATION_RUNTIME_SEVERITY=error so DrakeDeprecationWarnings
+#     from pydrake are propagated as errors. Without this, pydrake's
+#     default "once" filter sits at position 0 of the warnings filter
+#     list and shadows PYTHONWARNINGS=error for this category.
+#   PYTHONWARNINGS=error so any other Python warning is also promoted
+#     to a test failure.
+# Use this in place of add_test(NAME ...) for Python tests.
+function(drake_example_add_py_test)
+  cmake_parse_arguments(_arg "" "NAME" "" ${ARGN})
+  add_test(${ARGN})
+  set_property(TEST ${_arg_NAME} APPEND PROPERTY ENVIRONMENT
+    "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+    "PYTHONPATH=${drake_PYTHON_DIR}"
+    "PYTHONWARNINGS=error"
+  )
+endfunction()
+
+# Wrapper around CMake's add_test() for C++ example tests. Pure passthrough;
+# exists only so call sites are symmetric with drake_example_add_py_test().
+function(drake_example_add_cc_test)
+  add_test(${ARGN})
+endfunction()

--- a/drake_cmake_installed/CMakeLists.txt
+++ b/drake_cmake_installed/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.20...4.3)
 project(drake_cmake_installed)
 
 include(CTest)
+include(cmake/drake_example_add_test.cmake)
 
 find_package(drake CONFIG REQUIRED)
 

--- a/drake_cmake_installed/cmake/drake_example_add_test.cmake
+++ b/drake_cmake_installed/cmake/drake_example_add_test.cmake
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT-0
+
+include_guard(GLOBAL)
+
+# Wrapper around CMake's add_test() for Python example tests. In addition
+# to registering the test, it sets common environment defaults:
+#   PYTHONPATH so pydrake imports resolve.
+#   DRAKE_DEPRECATION_RUNTIME_SEVERITY=error so DrakeDeprecationWarnings
+#     from pydrake are propagated as errors. Without this, pydrake's
+#     default "once" filter sits at position 0 of the warnings filter
+#     list and shadows PYTHONWARNINGS=error for this category.
+#   PYTHONWARNINGS=error so any other Python warning is also promoted
+#     to a test failure.
+# Use this in place of add_test(NAME ...) for Python tests.
+function(drake_example_add_py_test)
+  cmake_parse_arguments(_arg "" "NAME" "" ${ARGN})
+  add_test(${ARGN})
+  set_property(TEST ${_arg_NAME} APPEND PROPERTY ENVIRONMENT
+    "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+    "PYTHONPATH=${drake_PYTHON_DIR}"
+    "PYTHONWARNINGS=error"
+  )
+endfunction()
+
+# Wrapper around CMake's add_test() for C++ example tests. Pure passthrough;
+# exists only so call sites are symmetric with drake_example_add_py_test().
+function(drake_example_add_cc_test)
+  add_test(${ARGN})
+endfunction()

--- a/drake_cmake_installed/src/CMakeLists.txt
+++ b/drake_cmake_installed/src/CMakeLists.txt
@@ -5,9 +5,6 @@ add_subdirectory(particle)
 add_subdirectory(simple_bindings)
 add_subdirectory(simple_continuous_time_system)
 
-add_test(NAME import_all_test COMMAND
+drake_example_add_py_test(NAME import_all_test COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/import_all_test.py"
-)
-set_tests_properties(import_all_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
 )

--- a/drake_cmake_installed/src/find_resource/CMakeLists.txt
+++ b/drake_cmake_installed/src/find_resource/CMakeLists.txt
@@ -1,11 +1,8 @@
 # SPDX-License-Identifier: MIT-0
 
 drake_example_add_executable(find_resource_example find_resource_example.cc)
-add_test(NAME find_resource_example COMMAND find_resource_example)
+drake_example_add_cc_test(NAME find_resource_example COMMAND find_resource_example)
 
-add_test(NAME find_resource_example_py COMMAND
+drake_example_add_py_test(NAME find_resource_example_py COMMAND
   "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/find_resource_example.py"
-)
-set_tests_properties(find_resource_example_py PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
 )

--- a/drake_cmake_installed/src/particle/CMakeLists.txt
+++ b/drake_cmake_installed/src/particle/CMakeLists.txt
@@ -4,14 +4,13 @@ drake_example_add_library(particle particle.cc particle.h)
 
 drake_example_add_executable(particle_test particle_test.cc)
 target_link_libraries(particle_test PUBLIC particle gtest)
-add_test(NAME cc_particle_test COMMAND particle_test)
+drake_example_add_cc_test(NAME cc_particle_test COMMAND particle_test)
 set_tests_properties(cc_particle_test PROPERTIES LABELS small TIMEOUT 60)
 
-add_test(NAME python_particle_test
+drake_example_add_py_test(NAME python_particle_test
   COMMAND Python3::Interpreter -B -m unittest particle_test
 )
 set_tests_properties(python_particle_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/particle_test.py"
   TIMEOUT 60

--- a/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_bindings/CMakeLists.txt
@@ -13,8 +13,8 @@ drake_example_pybind11_add_module(simple_bindings MODULE simple_bindings.cc)
 # https://github.com/pybind/pybind11/issues/2479
 set_target_properties(simple_bindings PROPERTIES CXX_VISIBILITY_PRESET default)
 
-add_test(NAME simple_bindings_test COMMAND
+drake_example_add_py_test(NAME simple_bindings_test COMMAND
     "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/simple_bindings_test.py")
-set_tests_properties(simple_bindings_test PROPERTIES
-    # Using `pybind11/tests/test_cmake_build/installed_target` as an example.
-    ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:simple_bindings>:${drake_PYTHON_DIR}")
+
+set_property(TEST simple_bindings_test APPEND PROPERTY ENVIRONMENT
+    "PYTHONPATH=$<TARGET_FILE_DIR:simple_bindings>:${drake_PYTHON_DIR}")

--- a/drake_cmake_installed/src/simple_continuous_time_system/CMakeLists.txt
+++ b/drake_cmake_installed/src/simple_continuous_time_system/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
 drake_example_add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
-add_test(NAME simple_continuous_time_system
+drake_example_add_cc_test(NAME simple_continuous_time_system
   COMMAND simple_continuous_time_system
 )

--- a/drake_cmake_installed_apt/CMakeLists.txt
+++ b/drake_cmake_installed_apt/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.20...4.3)
 project(drake_cmake_installed_apt)
 
 include(CTest)
+include(cmake/drake_example_add_test.cmake)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)

--- a/drake_cmake_installed_apt/cmake/drake_example_add_test.cmake
+++ b/drake_cmake_installed_apt/cmake/drake_example_add_test.cmake
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT-0
+
+include_guard(GLOBAL)
+
+# Wrapper around CMake's add_test() for Python example tests. In addition
+# to registering the test, it sets common environment defaults:
+#   PYTHONPATH so pydrake imports resolve.
+#   DRAKE_DEPRECATION_RUNTIME_SEVERITY=error so DrakeDeprecationWarnings
+#     from pydrake are propagated as errors. Without this, pydrake's
+#     default "once" filter sits at position 0 of the warnings filter
+#     list and shadows PYTHONWARNINGS=error for this category.
+#   PYTHONWARNINGS=error so any other Python warning is also promoted
+#     to a test failure.
+# Use this in place of add_test(NAME ...) for Python tests.
+function(drake_example_add_py_test)
+  cmake_parse_arguments(_arg "" "NAME" "" ${ARGN})
+  add_test(${ARGN})
+  set_property(TEST ${_arg_NAME} APPEND PROPERTY ENVIRONMENT
+    "DRAKE_DEPRECATION_RUNTIME_SEVERITY=error"
+    "PYTHONPATH=${drake_PYTHON_DIR}"
+    "PYTHONWARNINGS=error"
+  )
+endfunction()
+
+# Wrapper around CMake's add_test() for C++ example tests. Pure passthrough;
+# exists only so call sites are symmetric with drake_example_add_py_test().
+function(drake_example_add_cc_test)
+  add_test(${ARGN})
+endfunction()

--- a/drake_cmake_installed_apt/src/CMakeLists.txt
+++ b/drake_cmake_installed_apt/src/CMakeLists.txt
@@ -4,14 +4,13 @@ drake_example_add_library(particle particle.cc particle.h)
 
 drake_example_add_executable(particle_test particle_test.cc)
 target_link_libraries(particle_test PUBLIC particle gtest)
-add_test(NAME cc_particle_test COMMAND particle_test)
+drake_example_add_cc_test(NAME cc_particle_test COMMAND particle_test)
 set_tests_properties(cc_particle_test PROPERTIES LABELS small TIMEOUT 60)
 
-add_test(NAME python_particle_test
+drake_example_add_py_test(NAME python_particle_test
   COMMAND Python3::Interpreter -B -m unittest particle_test
 )
 set_tests_properties(python_particle_test PROPERTIES
-  ENVIRONMENT "PYTHONPATH=${drake_PYTHON_DIR}"
   LABELS small
   REQUIRED_FILES "${CMAKE_CURRENT_SOURCE_DIR}/particle_test.py"
   TIMEOUT 60

--- a/drake_pip/.github/ci_build_test
+++ b/drake_pip/.github/ci_build_test
@@ -5,6 +5,16 @@ set -euxo pipefail
 
 source env/bin/activate
 
+# Set two environment variables for promoting warnings to errors:
+#   DRAKE_DEPRECATION_RUNTIME_SEVERITY=error so DrakeDeprecationWarnings
+#     from pydrake are propagated as errors. Without this, pydrake's
+#     default "once" filter sits at position 0 of the warnings filter
+#     list and shadows PYTHONWARNINGS=error for this category.
+#   PYTHONWARNINGS=error so any other Python warning is also promoted
+#     to a test failure.
+export DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+export PYTHONWARNINGS=error
+
 cd src
 python3 particle_test.py
 

--- a/drake_poetry/.github/ci_build_test
+++ b/drake_poetry/.github/ci_build_test
@@ -5,6 +5,16 @@ set -euxo pipefail
 
 poetry --version
 
+# Set two environment variables for promoting warnings to errors:
+#   DRAKE_DEPRECATION_RUNTIME_SEVERITY=error so DrakeDeprecationWarnings
+#     from pydrake are propagated as errors. Without this, pydrake's
+#     default "once" filter sits at position 0 of the warnings filter
+#     list and shadows PYTHONWARNINGS=error for this category.
+#   PYTHONWARNINGS=error so any other Python warning is also promoted
+#     to a test failure.
+export DRAKE_DEPRECATION_RUNTIME_SEVERITY=error
+export PYTHONWARNINGS=error
+
 cd src
 poetry run python particle_test.py
 


### PR DESCRIPTION
Python warnings (including deprecation warnings) are promoted to errors. 

Closes https://github.com/RobotLocomotion/drake-external-examples/issues/159.

See also https://github.com/RobotLocomotion/drake-external-examples/pull/546 and https://github.com/RobotLocomotion/drake-external-examples/pull/556

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/559)
<!-- Reviewable:end -->
