### PR TITLE
[cmake] Move target helpers to separate files

### DIFF
--- a/drake_cmake_external/drake_external_examples/CMakeLists.txt
+++ b/drake_cmake_external/drake_external_examples/CMakeLists.txt
@@ -3,31 +3,19 @@
 cmake_minimum_required(VERSION 3.20...4.3)
 project(drake_external_examples)
 
-find_package(drake CONFIG REQUIRED)
-
-find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
-
-# Drake target configuration wrappers that set common toolchain-related
-# semantics (linking drake::drake, deprecation policy) across the example
-# targets in this project.
-function(drake_example_add_executable target)
-  add_executable(${target} ${ARGN})
-  target_link_libraries(${target} PUBLIC drake::drake)
-  # Treat any use of a deprecated Drake C++ API as a hard compile error.
-  # You might decide to ignore deprecation warnings in your own project.
-  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
-endfunction()
-
-function(drake_example_add_library target)
-  add_library(${target} ${ARGN})
-  target_link_libraries(${target} PUBLIC drake::drake)
-  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
-endfunction()
-
-drake_example_add_executable(simple_continuous_time_system simple_continuous_time_system.cc)
-
 include(CTest)
+include(cmake/drake_example_add_target.cmake)
 include(cmake/drake_example_add_test.cmake)
+
+find_package(drake CONFIG REQUIRED)
+find_package(Python3
+  ${drake_PYTHON_VERSION} EXACT REQUIRED
+  COMPONENTS Interpreter Development
+)
+
+drake_example_add_executable(simple_continuous_time_system
+  simple_continuous_time_system.cc
+)
 
 drake_example_add_cc_test(NAME simple_continuous_time_system
   COMMAND simple_continuous_time_system

--- a/drake_cmake_external/drake_external_examples/cmake/drake_example_add_target.cmake
+++ b/drake_cmake_external/drake_external_examples/cmake/drake_example_add_target.cmake
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT-0
+
+include_guard(GLOBAL)
+
+# Drake target configuration wrappers that set common toolchain-related
+# semantics (linking drake::drake, deprecation policy) across the example
+# targets in this project.
+
+function(drake_example_add_executable target)
+  add_executable(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  # Treat any use of a deprecated Drake C++ API as a hard compile error.
+  # You might decide to ignore deprecation warnings in your own project.
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_add_library target)
+  add_library(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()

--- a/drake_cmake_installed/CMakeLists.txt
+++ b/drake_cmake_installed/CMakeLists.txt
@@ -4,39 +4,20 @@ cmake_minimum_required(VERSION 3.20...4.3)
 project(drake_cmake_installed)
 
 include(CTest)
+include(cmake/drake_example_add_target.cmake)
 include(cmake/drake_example_add_test.cmake)
 
 find_package(drake CONFIG REQUIRED)
 
-find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3
+  ${drake_PYTHON_VERSION} EXACT REQUIRED
+  COMPONENTS Interpreter Development
+)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# Drake target configuration wrappers that set common toolchain-related
-# semantics (linking drake::drake, deprecation policy) across the example
-# targets in this project.
-function(drake_example_add_executable target)
-  add_executable(${target} ${ARGN})
-  target_link_libraries(${target} PUBLIC drake::drake)
-  # Treat any use of a deprecated Drake C++ API as a hard compile error.
-  # You might decide to ignore deprecation warnings in your own project.
-  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
-endfunction()
-
-function(drake_example_add_library target)
-  add_library(${target} ${ARGN})
-  target_link_libraries(${target} PUBLIC drake::drake)
-  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
-endfunction()
-
-function(drake_example_pybind11_add_module target)
-  pybind11_add_module(${target} ${ARGN})
-  target_link_libraries(${target} PUBLIC drake::drake)
-  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
-endfunction()
 
 add_subdirectory(src)
 add_subdirectory(third_party)

--- a/drake_cmake_installed/cmake/drake_example_add_target.cmake
+++ b/drake_cmake_installed/cmake/drake_example_add_target.cmake
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT-0
+
+include_guard(GLOBAL)
+
+# Drake target configuration wrappers that set common toolchain-related
+# semantics (linking drake::drake, deprecation policy) across the example
+# targets in this project.
+
+function(drake_example_add_executable target)
+  add_executable(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  # Treat any use of a deprecated Drake C++ API as a hard compile error.
+  # You might decide to ignore deprecation warnings in your own project.
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_add_library target)
+  add_library(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_pybind11_add_module target)
+  pybind11_add_module(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()

--- a/drake_cmake_installed_apt/CMakeLists.txt
+++ b/drake_cmake_installed_apt/CMakeLists.txt
@@ -4,14 +4,20 @@ cmake_minimum_required(VERSION 3.20...4.3)
 project(drake_cmake_installed_apt)
 
 include(CTest)
+include(cmake/drake_example_add_target.cmake)
 include(cmake/drake_example_add_test.cmake)
+
+find_package(drake CONFIG REQUIRED PATHS /opt/drake)
+find_package(Python3
+  ${drake_PYTHON_VERSION} EXACT REQUIRED
+  COMPONENTS Interpreter Development
+)
+find_package(Threads MODULE REQUIRED)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-find_package(Threads MODULE REQUIRED)
 
 add_library(gtest STATIC
   third_party/googletest/1.10/googletest/include/gtest/gtest.h
@@ -21,25 +27,5 @@ target_include_directories(gtest PUBLIC
   third_party/googletest/1.10/googletest/include
 )
 target_link_libraries(gtest Threads::Threads)
-
-find_package(drake CONFIG REQUIRED PATHS /opt/drake)
-find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
-
-# Drake target configuration wrappers that set common toolchain-related
-# semantics (linking drake::drake, deprecation policy) across the example
-# targets in this project.
-function(drake_example_add_executable target)
-  add_executable(${target} ${ARGN})
-  target_link_libraries(${target} PUBLIC drake::drake)
-  # Treat any use of a deprecated Drake C++ API as a hard compile error.
-  # You might decide to ignore deprecation warnings in your own project.
-  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
-endfunction()
-
-function(drake_example_add_library target)
-  add_library(${target} ${ARGN})
-  target_link_libraries(${target} PUBLIC drake::drake)
-  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
-endfunction()
 
 add_subdirectory(src)

--- a/drake_cmake_installed_apt/cmake/drake_example_add_target.cmake
+++ b/drake_cmake_installed_apt/cmake/drake_example_add_target.cmake
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT-0
+
+include_guard(GLOBAL)
+
+# Drake target configuration wrappers that set common toolchain-related
+# semantics (linking drake::drake, deprecation policy) across the example
+# targets in this project.
+
+function(drake_example_add_executable target)
+  add_executable(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  # Treat any use of a deprecated Drake C++ API as a hard compile error.
+  # You might decide to ignore deprecation warnings in your own project.
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()
+
+function(drake_example_add_library target)
+  add_library(${target} ${ARGN})
+  target_link_libraries(${target} PUBLIC drake::drake)
+  target_compile_options(${target} PRIVATE -Werror=deprecated-declarations)
+endfunction()

--- a/private/test/file_sync_test.py
+++ b/private/test/file_sync_test.py
@@ -51,6 +51,15 @@ COPIES = (
         "drake_bazel_download/.bazelversion",
         "drake_bazel_external/.bazelversion",
     ),
+    (
+        "drake_cmake_external/drake_external_examples/cmake/drake_example_add_target.cmake",
+        "drake_cmake_installed_apt/cmake/drake_example_add_target.cmake",
+    ),
+    (
+        "drake_cmake_external/drake_external_examples/cmake/drake_example_add_test.cmake",
+        "drake_cmake_installed/cmake/drake_example_add_test.cmake",
+        "drake_cmake_installed_apt/cmake/drake_example_add_test.cmake",
+    ),
 ) + tuple([
     (
         f"drake_cmake_installed/src/particle/{path}",


### PR DESCRIPTION
Apply the pattern from #559 to the changes in #556 to improve the organization and consistency of the examples.

While we're at it, add these to the file_sync_test for improved maintenance checks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/565)
<!-- Reviewable:end -->
