### PR TITLE
Silence diabolic rules_python default __init__.py warning

### DIFF
--- a/drake_bazel_download/.bazelrc
+++ b/drake_bazel_download/.bazelrc
@@ -13,6 +13,11 @@ build --features=prefer_pic_for_opt_binaries
 # Default build options.
 build --strip=never
 
+# The legacy __init__.py causes runfiles test flakes with Bazel >= 7, and
+# in any case we don't want this feature in the first place. We should
+# create all __init__.py files ourselves by hand anywhere we need them.
+build --incompatible_default_to_explicit_init_py
+
 # Default test options.
 build --test_output=errors
 build --test_summary=terse

--- a/drake_bazel_external/.bazelrc
+++ b/drake_bazel_external/.bazelrc
@@ -13,6 +13,11 @@ build --features=prefer_pic_for_opt_binaries
 # Default build options.
 build --strip=never
 
+# The legacy __init__.py causes runfiles test flakes with Bazel >= 7, and
+# in any case we don't want this feature in the first place. We should
+# create all __init__.py files ourselves by hand anywhere we need them.
+build --incompatible_default_to_explicit_init_py
+
 # Default test options.
 build --test_output=errors
 build --test_summary=terse


### PR DESCRIPTION
None of the python tests are libraries and so do not require an __init__.py at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/578)
<!-- Reviewable:end -->
