### PR TITLE
Update CI macOS binary artifact parameters to Tahoe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ on:
         description: 'Drake linux-noble-*-packaging .deb artifact URL'
         required: false
       mac_package_tar:
-        description: 'Drake mac-arm-sequoia-*-packaging .tar.gz artifact URL'
+        description: 'Drake mac-arm-tahoe-*-packaging .tar.gz artifact URL'
         required: false
       linux_wheel:
         description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
       mac_wheel:
-        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
+        description: 'Drake mac-arm-tahoe-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.

--- a/drake_cmake_installed/.github/workflows/ci.yml
+++ b/drake_cmake_installed/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
         description: 'Drake linux-noble-*-packaging .tar.gz artifact URL'
         required: false
       mac_package_tar:
-        description: 'Drake mac-arm-sequoia-*-packaging .tar.gz artifact URL'
+        description: 'Drake mac-arm-tahoe-*-packaging .tar.gz artifact URL'
         required: false
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.

--- a/drake_pip/.github/workflows/ci.yml
+++ b/drake_pip/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
         description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
       mac_wheel:
-        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
+        description: 'Drake mac-arm-tahoe-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.

--- a/drake_poetry/.github/workflows/ci.yml
+++ b/drake_poetry/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
         description: 'Drake linux-noble-*-wheel-*-release Python 3.12 artifact URL'
         required: false
       mac_wheel:
-        description: 'Drake mac-arm-sequoia-*-wheel-*-release Python 3.14 artifact URL'
+        description: 'Drake mac-arm-tahoe-*-wheel-*-release Python 3.14 artifact URL'
         required: false
 concurrency:
   # Cancel previous CI runs when additional commits are added to a pull request.


### PR DESCRIPTION
Track drake's removal of support for macOS Sequoia.

Towards robotlocomotion/drake#24941.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-external-examples/590)
<!-- Reviewable:end -->
